### PR TITLE
feat: Add Complaint MongoDB schema (SER-20)

### DIFF
--- a/backend/src/models/Complaint.js
+++ b/backend/src/models/Complaint.js
@@ -1,27 +1,31 @@
 import mongoose from 'mongoose';
 
+const SUBJECT_OPTIONS = [
+  'Provider did not show up',
+  'Poor quality of work',
+  'Billing or payment issue',
+  'Rude or unprofessional behavior',
+  'Verification or profile appeal',
+  'Incorrect service category',
+  'Safety concern',
+  'Other',
+];
+
 const complaintSchema = new mongoose.Schema(
   {
-    requesterId: {
+    complaintId: {
+      type: String,
+      unique: true,
+    },
+    userId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',
       required: true,
     },
-    requesterRole: {
-      type: String,
-      enum: ['customer', 'provider'],
-      required: true,
-    },
-    type: {
-      type: String,
-      enum: ['INCIDENT', 'APPEAL', 'REPORT'],
-      required: true,
-    },
     subject: {
       type: String,
+      enum: SUBJECT_OPTIONS,
       required: true,
-      trim: true,
-      maxlength: [200, 'Subject cannot exceed 200 characters'],
     },
     description: {
       type: String,
@@ -47,11 +51,21 @@ const complaintSchema = new mongoose.Schema(
   }
 );
 
+// Auto-generate a human-readable complaint reference ID (e.g. COMP-A1B2)
+complaintSchema.pre('save', function (next) {
+  if (!this.complaintId) {
+    const chars = Math.random().toString(36).substring(2, 6).toUpperCase();
+    this.complaintId = `COMP-${chars}`;
+  }
+  next();
+});
+
 // Indexes for efficient queries
-complaintSchema.index({ requesterId: 1 });
+complaintSchema.index({ userId: 1 });
 complaintSchema.index({ status: 1 });
 complaintSchema.index({ createdAt: -1 });
 
 const Complaint = mongoose.model('Complaint', complaintSchema);
 
+export { SUBJECT_OPTIONS };
 export default Complaint;


### PR DESCRIPTION
## What this does
- Adds `backend/src/models/Complaint.js` with Mongoose schema
- Human-readable `complaintId` (e.g. COMP-A1B2) auto-generated on save
- `subject` is an enum dropdown (covers both customer and provider scenarios)
- Fields: complaintId, userId, subject, description, priority, status, resolvedAt, timestamps

## Note
The complaints-ui PR depends on this merging first.