### PR TITLE
fix: opaque navbar glass effect and role-based FAQ sections

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -209,6 +209,20 @@ const App = () => {
         userId={user?.id || "guest"}
         userRole={(user?.role?.toLowerCase() as "customer" | "provider") || "customer"}
       />
+
+      {/* Chatbot coming soon bubble */}
+      <div className="fixed bottom-6 right-6 z-50 group">
+        <div className="absolute bottom-full right-0 mb-2 px-3 py-1.5 bg-slate-900 text-white text-xs font-semibold rounded-full whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+          AI Assistant — Coming Soon
+        </div>
+        <button
+          disabled
+          className="w-14 h-14 rounded-full bg-gradient-to-br from-teal-500 to-emerald-500 shadow-lg shadow-teal-500/30 flex items-center justify-center text-2xl cursor-not-allowed opacity-90 hover:scale-105 transition-transform duration-200"
+          aria-label="AI Assistant coming soon"
+        >
+          🤖
+        </button>
+      </div>
     </div>
   );
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -171,7 +171,7 @@ const App = () => {
           />
         );
       case "/faq":
-        return <FAQ />;
+        return <FAQ userRole={user?.role?.toLowerCase() as "customer" | "provider" | undefined} />;
       case "/users":
         return <UsersList onNavigate={navigate} />;
       case "/providers":

--- a/frontend/src/components/SupportModal.tsx
+++ b/frontend/src/components/SupportModal.tsx
@@ -4,9 +4,16 @@ import { X, MessageSquare, Loader2 } from "lucide-react";
 type UserRole = "customer" | "provider";
 type Priority = "LOW" | "MEDIUM" | "HIGH";
 
-const SUBJECT_OPTIONS = [
+const CUSTOMER_SUBJECTS = [
   "Provider did not show up",
   "Poor quality of work",
+  "Billing or payment issue",
+  "Rude or unprofessional behavior",
+  "Safety concern",
+  "Other",
+];
+
+const PROVIDER_SUBJECTS = [
   "Billing or payment issue",
   "Rude or unprofessional behavior",
   "Verification or profile appeal",
@@ -28,7 +35,8 @@ export const SupportModal: React.FC<SupportModalProps> = ({
   userId,
   userRole,
 }) => {
-  const [subject, setSubject] = useState(SUBJECT_OPTIONS[0]);
+  const subjectOptions = userRole === "provider" ? PROVIDER_SUBJECTS : CUSTOMER_SUBJECTS;
+  const [subject, setSubject] = useState(subjectOptions[0]);
   const [description, setDescription] = useState("");
   const [priority, setPriority] = useState<Priority>("MEDIUM");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -38,7 +46,7 @@ export const SupportModal: React.FC<SupportModalProps> = ({
   if (!isOpen) return null;
 
   const resetForm = () => {
-    setSubject(SUBJECT_OPTIONS[0]);
+    setSubject(subjectOptions[0]);
     setDescription("");
     setPriority("MEDIUM");
     setError(null);
@@ -159,7 +167,7 @@ export const SupportModal: React.FC<SupportModalProps> = ({
                   onChange={(e) => setSubject(e.target.value)}
                   className="w-full px-4 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-700 bg-white focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400 transition"
                 >
-                  {SUBJECT_OPTIONS.map((opt) => (
+                  {subjectOptions.map((opt) => (
                     <option key={opt} value={opt}>
                       {opt}
                     </option>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -66,3 +66,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer components {
+  .glass-panel {
+    @apply bg-white/80 backdrop-blur-xl border border-white/60 shadow-lg shadow-black/5;
+  }
+}

--- a/frontend/src/pages/FAQ.tsx
+++ b/frontend/src/pages/FAQ.tsx
@@ -113,8 +113,19 @@ const faqData: FAQSection[] = [
   },
 ];
 
-export const FAQ: React.FC = () => {
+interface FAQProps {
+  userRole?: "customer" | "provider";
+}
+
+export const FAQ: React.FC<FAQProps> = ({ userRole }) => {
   const [openItems, setOpenItems] = useState<Record<string, boolean>>({});
+
+  const visibleSections = faqData.filter((section) => {
+    if (!userRole) return true;
+    if (userRole === "customer") return section.title !== "For Providers";
+    if (userRole === "provider") return section.title !== "For Customers";
+    return true;
+  });
 
   const toggleItem = (key: string) => {
     setOpenItems((prev) => ({ ...prev, [key]: !prev[key] }));
@@ -147,7 +158,7 @@ export const FAQ: React.FC = () => {
       {/* FAQ Sections */}
       <section className="pb-24">
         <div className="max-w-3xl mx-auto px-4 space-y-12">
-          {faqData.map((section) => (
+          {visibleSections.map((section) => (
             <div key={section.title}>
               {/* Section heading */}
               <div className="flex items-center gap-3 mb-6">


### PR DESCRIPTION
## What this fixes / adds

### Bug fixes
- **Navbar transparency** — defined the missing `glass-panel` CSS class in `index.css`. Was causing the navbar to be see-through when content scrolled behind it (affects all pages)
- **FAQ role filtering** — logged-in customers now see only "For Customers" + "General" sections; providers see only "For Providers" + "General"; unauthenticated users see all sections

### Improvements
- **Support modal subjects filtered by role** — customers and providers now see only the complaint subjects relevant to them (e.g. providers don't see "Provider did not show up")
- **Chatbot coming soon bubble** — 🤖 fixed button bottom-right on all pages with "AI Assistant — Coming Soon" tooltip on hover

## Files changed
- `frontend/src/index.css` — added `glass-panel` class
- `frontend/src/pages/FAQ.tsx` — role-based section filtering
- `frontend/src/App.tsx` — pass `userRole` to FAQ + chatbot bubble
- `frontend/src/components/SupportModal.tsx` — role-based subject options
