### PR TITLE
feat: Sprint 2 — Profile UI enhancements + Vitest test infrastructure

### DIFF
--- a/frontend/src/pages/Profile_test.tsx
+++ b/frontend/src/pages/Profile_test.tsx
@@ -197,10 +197,10 @@ describe("Profile — provider user", () => {
 describe("Profile — 'me' profile", () => {
   beforeEach(() => {
     vi.mocked(profileService.getMe).mockResolvedValue({
-        success: true,
-        data: { ...customerUser, type: "user" } as unknown as typeof customerUser & { type: string },
-    });
-    });
+      success: true,
+      data: { ...customerUser, type: "user" as const },  // ← "user" as const, not as string
+    } as unknown as Awaited<ReturnType<typeof profileService.getMe>>);
+  });
 
   it("renders own profile without error", async () => {
     render(


### PR DESCRIPTION
## Sprint 3 — Design Profile UI

   ### Changes
   - Installed Vitest + @testing-library/react (first frontend test infrastructure)
   - Enhanced Profile.tsx: Edit Profile button (own profile), verified badge for providers,
     availability status indicator, hourly rate display
   - 10 passing Vitest tests covering loading, error, customer, provider, and "me" states
   - Confirmed: `npm run build` passes, Docker nginx container returns HTTP 200

   ### Test evidence
   ```
   ✓ Profile — loading state > shows a loading spinner initially
   ✓ Profile — error state > shows error message when no profileId is given
   ✓ Profile — customer user > renders customer full name
   ✓ Profile — customer user > shows Customer role badge
   ✓ Profile — provider user > renders provider business name
   ✓ Profile — provider user > shows Service Provider badge
   ✓ Profile — provider user > shows service category
   ✓ Profile — provider user > shows rating
   ✓ Profile — provider user > shows verified badge for verified provider
   ✓ Profile — 'me' profile > renders own profile without error
   ✓ Profile — 'me' profile > shows Edit Profile button for own profile
   ```