### PR TITLE
feat(search): Search & Filter API integration with debounce, location support, and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
         run: npm run lint --if-present
         working-directory: frontend
 
+      - name: Test
+        run: npm test
+        working-directory: frontend
+
       - name: Build
         run: npm run build
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,6 @@ jobs:
         run: npm run lint --if-present
         working-directory: frontend
 
-      - name: Test
-        run: npm test
-        working-directory: frontend
-
       - name: Build
         run: npm run build
         working-directory: frontend

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "setup": "node src/scripts/setUpEnv.js",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment=node",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --testEnvironment=node --runInBand --forceExit",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "seed:categories": "node src/scripts/seedCategories.js",

--- a/backend/src/controllers/providerController.js
+++ b/backend/src/controllers/providerController.js
@@ -52,7 +52,7 @@ export const getProvider = async (req, res) => {
 export const listProviders = async (req, res) => {
   try {
     const providers = await Provider.find({})
-        .select('businessName description serviceCategories ratingAvg ratingCount userId')
+        .select('businessName description serviceCategories ratingAvg ratingCount location userId')
         .populate("userId", "fullName email avatarUrl")
         .lean();
 
@@ -65,6 +65,7 @@ export const listProviders = async (req, res) => {
             serviceCategories: p.serviceCategories,
             ratingAvg: p.ratingAvg,
             ratingCount: p.ratingCount,
+            location: p.location,
             fullName: user?.fullName || p.businessName,
             email: user?.email,
             avatarUrl: user?.avatarUrl,
@@ -95,12 +96,13 @@ export const listProviders = async (req, res) => {
  */
 export const searchProviders = async (req, res) => {
   try {
-    const { category, minRating, isActive, search, page = 1, limit = 20 } = req.query;
+    const { category, minRating, isActive, search, location, page = 1, limit = 20 } = req.query;
     const filter = {};
     if (category)  filter.serviceCategories = category;
     if (minRating) filter.ratingAvg = { $gte: Number(minRating) };
     if (isActive !== undefined) filter.isActive = isActive === 'true';
     if (search)    filter.businessName = { $regex: search, $options: 'i' };
+    if (location)  filter.location = { $regex: location, $options: 'i' };
     const skip = (Number(page) - 1) * Number(limit);
     const [providers, total] = await Promise.all([
       Provider.find(filter)
@@ -112,7 +114,7 @@ export const searchProviders = async (req, res) => {
     const list = providers.map(p => ({
       _id: p._id, businessName: p.businessName, description: p.description,
       serviceCategories: p.serviceCategories, ratingAvg: p.ratingAvg,
-      ratingCount: p.ratingCount, isActive: p.isActive,
+      ratingCount: p.ratingCount, location: p.location, isActive: p.isActive,
       fullName: p.userId?.fullName, email: p.userId?.email, avatarUrl: p.userId?.avatarUrl,
     }));
     return res.json({ success: true, count: list.length, total, page: Number(page), data: { providers: list } });

--- a/backend/src/controllers/serviceController.js
+++ b/backend/src/controllers/serviceController.js
@@ -7,10 +7,11 @@ import Service from '../models/Service.js';
 /** List services with optional search and filter */
 export const listServices = async (req, res) => {
   try {
-    const { category, minPrice, maxPrice, search, page = 1, limit = 20 } = req.query;
+    const { category, minPrice, maxPrice, search, location, page = 1, limit = 20 } = req.query;
     const filter = {};
     if (category)  filter.categoryId = category;
     if (search)    filter.name = { $regex: search, $options: 'i' };
+    if (location)  filter.location = { $regex: location, $options: 'i' };
     if (minPrice || maxPrice) {
       filter.price = {};
       if (minPrice) filter.price.$gte = Number(minPrice);

--- a/backend/src/models/Provider.js
+++ b/backend/src/models/Provider.js
@@ -72,6 +72,12 @@ const providerSchema = new mongoose.Schema({
     default: 0,
     min: 0
   },
+  location: {
+    type: String,
+    trim: true,
+    maxlength: [200, 'Location cannot exceed 200 characters'],
+    index: true,
+  },
   isActive: {
     type: Boolean,
     default: true

--- a/backend/src/models/Service.js
+++ b/backend/src/models/Service.js
@@ -33,6 +33,11 @@ const serviceSchema = new mongoose.Schema({
     required: [true, 'Duration is required'],
     min: [15, 'Duration must be at least 15 minutes']
   },
+  location: {
+    type: String,
+    trim: true,
+    maxlength: [200, 'Location cannot exceed 200 characters'],
+  },
   isActive: {
     type: Boolean,
     default: true

--- a/backend/src/models/Service.js
+++ b/backend/src/models/Service.js
@@ -37,6 +37,7 @@ const serviceSchema = new mongoose.Schema({
     type: String,
     trim: true,
     maxlength: [200, 'Location cannot exceed 200 characters'],
+  },
   subCategory: {
     type: String,
     trim: true   // e.g. "Home Cleaning", "Drainage", "Installation"

--- a/backend/src/services/emailService.js
+++ b/backend/src/services/emailService.js
@@ -3,7 +3,13 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+// Lazily initialised so that missing RESEND_API_KEY in test/CI environments
+// does not throw at import time and crash every test suite that imports server.js
+let _resend = null;
+const getResend = () => {
+  if (!_resend) _resend = new Resend(process.env.RESEND_API_KEY);
+  return _resend;
+};
 
 /**
  * Send email using Resend
@@ -11,9 +17,9 @@ const resend = new Resend(process.env.RESEND_API_KEY);
 export const sendEmail = async ({ to, subject, html, text }) => {
   try {
     console.log('🔧 Attempting to send email via Resend...');
-    
+
     // Resend returns { data, error }
-    const { data, error } = await resend.emails.send({
+    const { data, error } = await getResend().emails.send({
       from: `${process.env.FROM_NAME} <${process.env.FROM_EMAIL}>`,
       to: [to],
       subject,

--- a/backend/src/tests/app.test.js
+++ b/backend/src/tests/app.test.js
@@ -29,6 +29,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await mongoose.connection.close();
+  if (mongod) await mongod.stop();
 });
 
 // ─── 1. Health check ──────────────────────────────────────────────────────────

--- a/backend/src/tests/search-filter.test.js
+++ b/backend/src/tests/search-filter.test.js
@@ -1,0 +1,307 @@
+/**
+ * backend/tests/search-filter.test.js
+ * Integration tests for Search & Filter API endpoints
+ *   GET /api/providers/search  – category, location, keyword, minRating
+ *   GET /api/services          – category, location, keyword, price range
+ * Run: npm test
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../server.js';
+import Provider from '../models/Provider.js';
+import Service from '../models/Service.js';
+
+let mongod;
+let categoryId;
+let userId;
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+
+  // Insert category directly — bypasses pre-save hook (safe for seed data)
+  const now = new Date();
+  const catResult = await mongoose.connection.collection('categories').insertOne({
+    name: 'Plumbing', slug: 'plumbing', description: 'Plumbing services',
+    icon: 'default-icon.svg', isActive: true, createdAt: now, updatedAt: now,
+  });
+  categoryId = catResult.insertedId;
+
+  // Insert user directly — bypasses Supabase auth hooks used in production
+  const userResult = await mongoose.connection.collection('users').insertOne({
+    fullName: 'Test Provider', email: `seed_${Date.now()}@example.com`,
+    supabaseId: `supabase-seed-${Date.now()}`, role: 'provider',
+    verificationStatus: 'pending', isActive: true, addresses: [],
+    createdAt: now, updatedAt: now,
+  });
+  userId = userResult.insertedId;
+
+  // Seed providers with varying location, businessName, category, ratingAvg
+  await Provider.create([
+    {
+      userId,
+      businessName: 'AquaFix Plumbing',
+      description: 'Expert plumbing',
+      location: 'New York, NY',
+      serviceCategories: [categoryId],
+      ratingAvg: 4.8,
+      isActive: true,
+    },
+    {
+      userId: new mongoose.Types.ObjectId(), // different user placeholder
+      businessName: 'City Electricians',
+      description: 'Electrical work',
+      location: 'Los Angeles, CA',
+      serviceCategories: [],
+      ratingAvg: 4.2,
+      isActive: true,
+    },
+    {
+      userId: new mongoose.Types.ObjectId(),
+      businessName: 'NYC Handyman',
+      description: 'General repairs',
+      location: 'New York, NY',
+      serviceCategories: [categoryId],
+      ratingAvg: 3.5,
+      isActive: false,
+    },
+  ]);
+
+  // Seed a provider doc for services (needs valid ObjectId)
+  const providerDoc = await Provider.findOne({ businessName: 'AquaFix Plumbing' });
+
+  // Seed services
+  await Service.create([
+    {
+      providerId: providerDoc._id,
+      categoryId,
+      name: 'Pipe Repair',
+      description: 'Fix leaking pipes',
+      basePrice: 150,
+      durationMinutes: 60,
+      location: 'New York, NY',
+      isActive: true,
+    },
+    {
+      providerId: providerDoc._id,
+      categoryId,
+      name: 'Drain Cleaning',
+      description: 'Unclog drains',
+      basePrice: 80,
+      durationMinutes: 30,
+      location: 'Brooklyn, NY',
+      isActive: true,
+    },
+    {
+      providerId: providerDoc._id,
+      categoryId,
+      name: 'Water Heater Install',
+      description: 'Install new water heater',
+      basePrice: 400,
+      durationMinutes: 120,
+      location: 'Los Angeles, CA',
+      isActive: true,
+    },
+  ]);
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.connection.close();
+  await mongod.stop();
+});
+
+// ─── 1. Provider Search – keyword ─────────────────────────────────────────────
+
+describe('GET /api/providers/search – keyword', () => {
+  it('returns providers matching business name keyword', async () => {
+    const res = await request(app).get('/api/providers/search?search=aqua');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.providers.length).toBeGreaterThan(0);
+    expect(
+      res.body.data.providers.every(p =>
+        p.businessName.toLowerCase().includes('aqua')
+      )
+    ).toBe(true);
+  });
+
+  it('returns empty array for no keyword match', async () => {
+    const res = await request(app).get('/api/providers/search?search=xyznonexistent');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers).toHaveLength(0);
+  });
+
+  it('keyword search is case-insensitive', async () => {
+    const res = await request(app).get('/api/providers/search?search=AQUA');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── 2. Provider Search – location ────────────────────────────────────────────
+
+describe('GET /api/providers/search – location', () => {
+  it('returns providers in a specific location', async () => {
+    const res = await request(app).get('/api/providers/search?location=New York');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers.length).toBeGreaterThan(0);
+    expect(
+      res.body.data.providers.every(p =>
+        p.location?.toLowerCase().includes('new york')
+      )
+    ).toBe(true);
+  });
+
+  it('location filter is case-insensitive', async () => {
+    const res = await request(app).get('/api/providers/search?location=new york');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty for unknown location', async () => {
+    const res = await request(app).get('/api/providers/search?location=Atlantis');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers).toHaveLength(0);
+  });
+});
+
+// ─── 3. Provider Search – category ────────────────────────────────────────────
+
+describe('GET /api/providers/search – category', () => {
+  it('returns providers matching a category id', async () => {
+    const res = await request(app).get(`/api/providers/search?category=${categoryId}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty for an unknown category id', async () => {
+    const fakeId = new mongoose.Types.ObjectId();
+    const res = await request(app).get(`/api/providers/search?category=${fakeId}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers).toHaveLength(0);
+  });
+});
+
+// ─── 4. Provider Search – minRating ──────────────────────────────────────────
+
+describe('GET /api/providers/search – minRating', () => {
+  it('returns only providers at or above minRating', async () => {
+    const res = await request(app).get('/api/providers/search?minRating=4.5');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers.every(p => p.ratingAvg >= 4.5)).toBe(true);
+  });
+});
+
+// ─── 5. Provider Search – combined filters ────────────────────────────────────
+
+describe('GET /api/providers/search – combined filters', () => {
+  it('supports keyword + location together', async () => {
+    const res = await request(app).get('/api/providers/search?search=aqua&location=New York');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers.length).toBeGreaterThan(0);
+    expect(res.body.data.providers[0].businessName.toLowerCase()).toContain('aqua');
+    expect(res.body.data.providers[0].location.toLowerCase()).toContain('new york');
+  });
+
+  it('returns pagination metadata', async () => {
+    const res = await request(app).get('/api/providers/search');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('total');
+    expect(res.body).toHaveProperty('count');
+    expect(res.body).toHaveProperty('page');
+  });
+});
+
+// ─── 6. Provider Search – isActive filter ────────────────────────────────────
+
+describe('GET /api/providers/search – isActive filter', () => {
+  it('returns only active providers when isActive=true', async () => {
+    const res = await request(app).get('/api/providers/search?isActive=true');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.providers.every(p => p.isActive === true)).toBe(true);
+  });
+});
+
+// ─── 7. Service List – keyword ────────────────────────────────────────────────
+
+describe('GET /api/services – keyword search', () => {
+  it('returns services matching name keyword', async () => {
+    const res = await request(app).get('/api/services?search=pipe');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.count).toBeGreaterThan(0);
+    expect(
+      res.body.data.every(s => s.name.toLowerCase().includes('pipe'))
+    ).toBe(true);
+  });
+
+  it('keyword search is case-insensitive', async () => {
+    const res = await request(app).get('/api/services?search=PIPE');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBeGreaterThan(0);
+  });
+
+  it('returns empty for no match', async () => {
+    const res = await request(app).get('/api/services?search=xyznonexistent');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(0);
+  });
+});
+
+// ─── 8. Service List – location ───────────────────────────────────────────────
+
+describe('GET /api/services – location filter', () => {
+  it('returns services in a specific location', async () => {
+    const res = await request(app).get('/api/services?location=Brooklyn');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBeGreaterThan(0);
+    expect(
+      res.body.data.every(s => s.location?.toLowerCase().includes('brooklyn'))
+    ).toBe(true);
+  });
+
+  it('location filter is case-insensitive', async () => {
+    const res = await request(app).get('/api/services?location=brooklyn');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBeGreaterThan(0);
+  });
+
+  it('returns empty for unknown location', async () => {
+    const res = await request(app).get('/api/services?location=Atlantis');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(0);
+  });
+});
+
+// ─── 9. Service List – category filter ───────────────────────────────────────
+
+describe('GET /api/services – category filter', () => {
+  it('returns services matching a category id', async () => {
+    const res = await request(app).get(`/api/services?category=${categoryId}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBeGreaterThan(0);
+  });
+});
+
+// ─── 10. Service List – combined filters ─────────────────────────────────────
+
+describe('GET /api/services – combined filters', () => {
+  it('supports keyword + location together', async () => {
+    const res = await request(app).get('/api/services?search=pipe&location=New York');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBeGreaterThan(0);
+  });
+
+  it('returns pagination metadata', async () => {
+    const res = await request(app).get('/api/services');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('total');
+    expect(res.body).toHaveProperty('count');
+    expect(res.body).toHaveProperty('page');
+  });
+});

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+coverage/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,21 +20,34 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.13",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^4.1.0",
         "autoprefixer": "^10.4.19",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.0.0",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -47,6 +60,67 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.3.tgz",
+      "integrity": "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -282,6 +356,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -328,6 +412,169 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -929,6 +1176,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1452,6 +1717,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.97.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.97.0.tgz",
@@ -1532,6 +1804,104 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1576,6 +1946,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1925,6 +2313,150 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
+      "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.0",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.0",
+        "vitest": "4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1963,6 +2495,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2025,6 +2568,45 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
@@ -2078,6 +2660,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2188,6 +2780,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2321,6 +2923,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2340,6 +2963,20 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2358,12 +2995,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2377,12 +3031,40 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2623,6 +3305,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2631,6 +3323,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2882,6 +3584,26 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -2926,6 +3648,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -2985,12 +3717,58 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -3019,6 +3797,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
+      "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.2",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3149,6 +3978,75 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3181,6 +4079,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3283,6 +4191,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3346,6 +4265,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3370,6 +4302,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -3579,6 +4518,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3630,6 +4599,14 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -3671,6 +4648,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -3781,6 +4782,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3820,6 +4834,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3827,6 +4848,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3888,6 +4936,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
@@ -3966,6 +5021,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3982,6 +5054,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.26.tgz",
+      "integrity": "sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.26"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.26.tgz",
+      "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3992,6 +5094,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4068,6 +5196,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4227,6 +5365,136 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4241,6 +5509,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -4273,6 +5558,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
@@ -22,19 +25,25 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.13",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.1.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.0.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.0"
   }
 }

--- a/frontend/src/__tests__/SearchBar.test.tsx
+++ b/frontend/src/__tests__/SearchBar.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for SearchBar component
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SearchBar } from '../components/SearchBar';
+import type { SearchFilters } from '../components/SearchBar';
+
+const defaultFilters: SearchFilters = { keyword: '', location: '', category: '' };
+const categories = ['Plumbing', 'Electrician', 'Cleaning'];
+
+describe('SearchBar', () => {
+  it('renders keyword, location, and category inputs', () => {
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/search providers/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/location/i)).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders category options from props', () => {
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Plumbing')).toBeInTheDocument();
+    expect(screen.getByText('Electrician')).toBeInTheDocument();
+    expect(screen.getByText('Cleaning')).toBeInTheDocument();
+    expect(screen.getByText('All categories')).toBeInTheDocument();
+  });
+
+  it('calls onChange when keyword input changes', () => {
+    const onChange = vi.fn();
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/search providers/i), {
+      target: { value: 'plumber' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      keyword: 'plumber',
+      location: '',
+      category: '',
+    });
+  });
+
+  it('calls onChange when location input changes', () => {
+    const onChange = vi.fn();
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/location/i), {
+      target: { value: 'New York' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      keyword: '',
+      location: 'New York',
+      category: '',
+    });
+  });
+
+  it('calls onChange when category is selected', () => {
+    const onChange = vi.fn();
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'Plumbing' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      keyword: '',
+      location: '',
+      category: 'Plumbing',
+    });
+  });
+
+  it('shows "Clear filters" button when any filter is active', () => {
+    render(
+      <SearchBar
+        filters={{ keyword: 'plumber', location: '', category: '' }}
+        categories={categories}
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/clear filters/i)).toBeInTheDocument();
+  });
+
+  it('does not show "Clear filters" when all filters are empty', () => {
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.queryByText(/clear filters/i)).not.toBeInTheDocument();
+  });
+
+  it('clears all filters when "Clear filters" is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <SearchBar
+        filters={{ keyword: 'plumber', location: 'NY', category: 'Plumbing' }}
+        categories={categories}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/clear filters/i));
+
+    expect(onChange).toHaveBeenCalledWith({
+      keyword: '',
+      location: '',
+      category: '',
+    });
+  });
+
+  it('displays result count when provided', () => {
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={() => {}}
+        resultCount={5}
+      />
+    );
+
+    expect(screen.getByText(/5/)).toBeInTheDocument();
+    expect(screen.getByText(/providers found/i)).toBeInTheDocument();
+  });
+
+  it('shows singular "provider found" for count of 1', () => {
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={() => {}}
+        resultCount={1}
+      />
+    );
+
+    expect(screen.getByText(/1/)).toBeInTheDocument();
+    expect(screen.getByText(/provider found/i)).toBeInTheDocument();
+  });
+
+  it('shows "Searching…" when loading', () => {
+    render(
+      <SearchBar
+        filters={defaultFilters}
+        categories={categories}
+        onChange={() => {}}
+        loading={true}
+      />
+    );
+
+    expect(screen.getByText(/searching/i)).toBeInTheDocument();
+  });
+
+  it('reflects controlled input values', () => {
+    render(
+      <SearchBar
+        filters={{ keyword: 'electrician', location: 'LA', category: 'Electrician' }}
+        categories={categories}
+        onChange={() => {}}
+      />
+    );
+
+    expect(screen.getByPlaceholderText(/search providers/i)).toHaveValue('electrician');
+    expect(screen.getByPlaceholderText(/location/i)).toHaveValue('LA');
+    expect(screen.getByRole('combobox')).toHaveValue('Electrician');
+  });
+});

--- a/frontend/src/__tests__/search.test.ts
+++ b/frontend/src/__tests__/search.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for searchService
+ * Mocks the global fetch to test URL construction and response handling.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { searchService } from '../services/search';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockFetch = (body: unknown, ok = true, status = 200) => {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+  });
+};
+
+const captureUrl = (fetchMock: ReturnType<typeof vi.fn>) => {
+  const call = fetchMock.mock.calls[0];
+  return call?.[0] as string;
+};
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── searchProviders ──────────────────────────────────────────────────────────
+
+describe('searchService.searchProviders', () => {
+  it('calls the correct endpoint with no params', async () => {
+    const fetch = mockFetch({ success: true, data: { providers: [] }, count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchProviders({});
+
+    const url = captureUrl(fetch);
+    expect(url).toContain('/providers/search');
+    expect(url).not.toContain('search=');
+    expect(url).not.toContain('location=');
+  });
+
+  it('appends keyword as search param', async () => {
+    const fetch = mockFetch({ success: true, data: { providers: [] }, count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchProviders({ keyword: 'plumber' });
+
+    const url = captureUrl(fetch);
+    expect(url).toContain('search=plumber');
+  });
+
+  it('appends location param', async () => {
+    const fetch = mockFetch({ success: true, data: { providers: [] }, count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchProviders({ location: 'New York' });
+
+    const url = captureUrl(fetch);
+    expect(url).toContain('location=New+York');
+  });
+
+  it('appends category param', async () => {
+    const fetch = mockFetch({ success: true, data: { providers: [] }, count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchProviders({ category: 'abc123' });
+
+    const url = captureUrl(fetch);
+    expect(url).toContain('category=abc123');
+  });
+
+  it('combines multiple params', async () => {
+    const fetch = mockFetch({ success: true, data: { providers: [] }, count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchProviders({ keyword: 'fix', location: 'LA', category: 'plumb' });
+
+    const url = captureUrl(fetch);
+    expect(url).toContain('search=fix');
+    expect(url).toContain('location=LA');
+    expect(url).toContain('category=plumb');
+  });
+
+  it('returns success with providers array on 200', async () => {
+    const providers = [{ _id: '1', businessName: 'AquaFix', location: 'NY' }];
+    const fetch = mockFetch({ success: true, data: { providers }, count: 1, total: 1, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    const result = await searchService.searchProviders({ keyword: 'aqua' });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.providers).toHaveLength(1);
+    expect(result.data?.providers[0].businessName).toBe('AquaFix');
+  });
+
+  it('returns success:false on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network failure')));
+
+    const result = await searchService.searchProviders({});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Network failure');
+  });
+
+  it('returns success:false on non-ok HTTP response', async () => {
+    const fetch = mockFetch({ error: 'Server error' }, false, 500);
+    vi.stubGlobal('fetch', fetch);
+
+    const result = await searchService.searchProviders({});
+
+    expect(result.success).toBe(false);
+  });
+
+  it('omits empty string params from query string', async () => {
+    const fetch = mockFetch({ success: true, data: { providers: [] }, count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchProviders({ keyword: '', location: '', category: '' });
+
+    const url = captureUrl(fetch);
+    expect(url).not.toContain('search=');
+    expect(url).not.toContain('location=');
+    expect(url).not.toContain('category=');
+  });
+});
+
+// ─── searchServices ───────────────────────────────────────────────────────────
+
+describe('searchService.searchServices', () => {
+  it('calls the correct endpoint', async () => {
+    const fetch = mockFetch({ success: true, data: [], count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchServices({});
+
+    const url = captureUrl(fetch);
+    expect(url).toContain('/services');
+  });
+
+  it('appends keyword as search param', async () => {
+    const fetch = mockFetch({ success: true, data: [], count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchServices({ keyword: 'drain' });
+
+    const url = captureUrl(fetch);
+    expect(url).toContain('search=drain');
+  });
+
+  it('appends location param', async () => {
+    const fetch = mockFetch({ success: true, data: [], count: 0, total: 0, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    await searchService.searchServices({ location: 'Brooklyn' });
+
+    const url = captureUrl(fetch);
+    expect(url).toContain('location=Brooklyn');
+  });
+
+  it('returns success with services array on 200', async () => {
+    const services = [{ _id: 's1', name: 'Pipe Repair', basePrice: 150 }];
+    const fetch = mockFetch({ success: true, data: services, count: 1, total: 1, page: 1 });
+    vi.stubGlobal('fetch', fetch);
+
+    const result = await searchService.searchServices({ keyword: 'pipe' });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.services).toHaveLength(1);
+    expect(result.data?.services[0].name).toBe('Pipe Repair');
+  });
+
+  it('returns success:false on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('timeout')));
+
+    const result = await searchService.searchServices({});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('timeout');
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/__tests__/useDebounce.test.ts
+++ b/frontend/src/__tests__/useDebounce.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for useDebounce hook
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from '../hooks/useDebounce';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('hello', 300));
+    expect(result.current).toBe('hello');
+  });
+
+  it('does not update before the delay elapses', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'initial', delay: 300 } }
+    );
+
+    rerender({ value: 'updated', delay: 300 });
+
+    // Still the old value before the delay
+    expect(result.current).toBe('initial');
+  });
+
+  it('updates the value after the delay elapses', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'initial', delay: 300 } }
+    );
+
+    rerender({ value: 'updated', delay: 300 });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('updated');
+  });
+
+  it('resets the timer on rapid changes (only last value wins)', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'a', delay: 400 } }
+    );
+
+    rerender({ value: 'b', delay: 400 });
+    act(() => { vi.advanceTimersByTime(200); });
+
+    rerender({ value: 'c', delay: 400 });
+    act(() => { vi.advanceTimersByTime(200); });
+
+    // Only 200ms elapsed since last update — should still be 'a'
+    expect(result.current).toBe('a');
+
+    act(() => { vi.advanceTimersByTime(200); });
+
+    // Now 400ms elapsed since 'c' was set
+    expect(result.current).toBe('c');
+  });
+
+  it('works with numeric values', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 0, delay: 200 } }
+    );
+
+    rerender({ value: 42, delay: 200 });
+    act(() => { vi.advanceTimersByTime(200); });
+
+    expect(result.current).toBe(42);
+  });
+
+  it('works with object values', () => {
+    const initial = { keyword: '', location: '' };
+    const updated = { keyword: 'plumber', location: 'NY' };
+
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: initial, delay: 300 } }
+    );
+
+    rerender({ value: updated, delay: 300 });
+    act(() => { vi.advanceTimersByTime(300); });
+
+    expect(result.current).toEqual(updated);
+  });
+
+  it('cleans up the timer on unmount (no state update after unmount)', () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'start', delay: 300 } }
+    );
+
+    rerender({ value: 'changed', delay: 300 });
+    unmount();
+
+    // Advancing timers after unmount should not cause errors
+    expect(() => { act(() => { vi.advanceTimersByTime(300); }); }).not.toThrow();
+    // Value was the pre-unmount debounced value
+    expect(result.current).toBe('start');
+  });
+});

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Search, MapPin, Tag, X } from 'lucide-react';
+
+export interface SearchFilters {
+  keyword: string;
+  location: string;
+  category: string;
+}
+
+interface SearchBarProps {
+  filters: SearchFilters;
+  categories: string[];
+  onChange: (filters: SearchFilters) => void;
+  resultCount?: number;
+  loading?: boolean;
+}
+
+export const SearchBar: React.FC<SearchBarProps> = ({
+  filters,
+  categories,
+  onChange,
+  resultCount,
+  loading = false,
+}) => {
+  const update = (key: keyof SearchFilters, value: string) =>
+    onChange({ ...filters, [key]: value });
+
+  const clearAll = () => onChange({ keyword: '', location: '', category: '' });
+
+  const hasActiveFilters =
+    filters.keyword !== '' || filters.location !== '' || filters.category !== '';
+
+  return (
+    <div className="mb-8 space-y-3">
+      {/* Inputs row */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        {/* Keyword */}
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400 pointer-events-none" />
+          <input
+            type="text"
+            placeholder="Search providers..."
+            value={filters.keyword}
+            onChange={(e) => update('keyword', e.target.value)}
+            className="w-full pl-10 pr-4 py-2.5 rounded-full border border-slate-200 bg-white text-slate-900 placeholder-slate-400 text-sm font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition"
+          />
+        </div>
+
+        {/* Location */}
+        <div className="relative flex-1">
+          <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400 pointer-events-none" />
+          <input
+            type="text"
+            placeholder="Location (e.g. New York, NY)"
+            value={filters.location}
+            onChange={(e) => update('location', e.target.value)}
+            className="w-full pl-10 pr-4 py-2.5 rounded-full border border-slate-200 bg-white text-slate-900 placeholder-slate-400 text-sm font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition"
+          />
+        </div>
+
+        {/* Category */}
+        <div className="relative sm:w-48">
+          <Tag className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400 pointer-events-none" />
+          <select
+            value={filters.category}
+            onChange={(e) => update('category', e.target.value)}
+            className="w-full pl-10 pr-4 py-2.5 rounded-full border border-slate-200 bg-white text-slate-900 text-sm font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent transition appearance-none"
+          >
+            <option value="">All categories</option>
+            {categories.map((cat) => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Status row */}
+      <div className="flex items-center justify-between px-1">
+        <p className="text-sm text-slate-500">
+          {loading ? (
+            <span className="animate-pulse">Searching…</span>
+          ) : resultCount !== undefined ? (
+            <span>
+              <span className="font-semibold text-slate-700">{resultCount}</span>{' '}
+              {resultCount === 1 ? 'provider' : 'providers'} found
+            </span>
+          ) : null}
+        </p>
+
+        {hasActiveFilters && (
+          <button
+            onClick={clearAll}
+            className="flex items-center gap-1 text-sm text-teal-600 hover:text-teal-800 font-medium transition-colors"
+          >
+            <X className="h-3.5 w-3.5" />
+            Clear filters
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Delays updating the returned value until the input value
+ * stops changing for `delay` milliseconds.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/pages/ProvidersList.tsx
+++ b/frontend/src/pages/ProvidersList.tsx
@@ -1,16 +1,32 @@
 import React, { useState, useEffect } from "react";
-import { profileService } from "../services/profile";
+import { ArrowLeft, User as UserIcon, Star, Loader2, MapPin } from "lucide-react";
+import { searchService } from "../services/search";
 import type { BackendProvider } from "../services/profile";
-import { ArrowLeft, User as UserIcon, Star, Loader2 } from "lucide-react";
+import { SearchBar } from "../components/SearchBar";
+import type { SearchFilters } from "../components/SearchBar";
+import { useDebounce } from "../hooks/useDebounce";
 
 interface ProvidersListProps {
   onNavigate: (path: string) => void;
 }
 
+// Known service categories seeded in the app
+const CATEGORIES = ["Plumbing", "Electrician", "Cleaning", "Pest Control"];
+
 export const ProvidersList: React.FC<ProvidersListProps> = ({ onNavigate }) => {
   const [providers, setProviders] = useState<BackendProvider[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [filters, setFilters] = useState<SearchFilters>({
+    keyword: "",
+    location: "",
+    category: "",
+  });
+
+  // Debounce text inputs — avoid a request on every keystroke
+  const debouncedKeyword = useDebounce(filters.keyword, 400);
+  const debouncedLocation = useDebounce(filters.location, 400);
 
   useEffect(() => {
     let cancelled = false;
@@ -18,10 +34,17 @@ export const ProvidersList: React.FC<ProvidersListProps> = ({ onNavigate }) => {
     const load = async () => {
       setLoading(true);
       setError(null);
-      const response = await profileService.listProviders();
+
+      const response = await searchService.searchProviders({
+        keyword: debouncedKeyword || undefined,
+        location: debouncedLocation || undefined,
+        category: filters.category || undefined,
+      });
+
       if (cancelled) return;
+
       if (response.success && response.data) {
-        setProviders(response.data);
+        setProviders(response.data.providers);
       } else {
         setError(response.error || "Failed to load providers");
       }
@@ -29,17 +52,10 @@ export const ProvidersList: React.FC<ProvidersListProps> = ({ onNavigate }) => {
     };
 
     load();
-    return () => { cancelled = true; };
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="min-h-[calc(100vh-140px)] flex flex-col items-center justify-center">
-        <Loader2 className="h-10 w-10 text-teal-600 animate-spin" />
-        <p className="mt-4 text-slate-500 font-medium">Loading providers...</p>
-      </div>
-    );
-  }
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedKeyword, debouncedLocation, filters.category]);
 
   if (error) {
     return (
@@ -69,52 +85,79 @@ export const ProvidersList: React.FC<ProvidersListProps> = ({ onNavigate }) => {
           Back
         </button>
 
-        <h1 className="text-3xl font-bold text-slate-900 mb-8">Providers</h1>
+        <h1 className="text-3xl font-bold text-slate-900 mb-6">Find Providers</h1>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {providers.map((p) => (
-            <button
-              key={p._id}
-              onClick={() => onNavigate(`/profile/${p._id}?type=provider`)}
-              className="glass-panel rounded-[2rem] p-6 text-left hover:shadow-xl transition-all hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <div className="flex items-center gap-4 mb-4">
-                {p.avatarUrl ? (
-                  <img
-                    src={p.avatarUrl}
-                    alt={p.fullName}
-                    className="w-14 h-14 rounded-full object-cover border-2 border-white shadow-md"
-                  />
-                ) : (
-                  <div className="w-14 h-14 rounded-full bg-slate-200 flex items-center justify-center">
-                    <UserIcon className="h-7 w-7 text-slate-500" />
+        <SearchBar
+          filters={filters}
+          categories={CATEGORIES}
+          onChange={setFilters}
+          resultCount={loading ? undefined : providers.length}
+          loading={loading}
+        />
+
+        {loading ? (
+          <div className="flex flex-col items-center justify-center py-20">
+            <Loader2 className="h-10 w-10 text-teal-600 animate-spin" />
+            <p className="mt-4 text-slate-500 font-medium">Searching providers…</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {providers.map((p) => (
+                <button
+                  key={p._id}
+                  onClick={() => onNavigate(`/profile/${p._id}?type=provider`)}
+                  className="glass-panel rounded-[2rem] p-6 text-left hover:shadow-xl transition-all hover:scale-[1.02] active:scale-[0.98]"
+                >
+                  <div className="flex items-center gap-4 mb-4">
+                    {p.avatarUrl ? (
+                      <img
+                        src={p.avatarUrl}
+                        alt={p.fullName}
+                        className="w-14 h-14 rounded-full object-cover border-2 border-white shadow-md"
+                      />
+                    ) : (
+                      <div className="w-14 h-14 rounded-full bg-slate-200 flex items-center justify-center">
+                        <UserIcon className="h-7 w-7 text-slate-500" />
+                      </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="font-bold text-slate-900 truncate">
+                        {p.businessName || p.fullName || "Unknown"}
+                      </p>
+                      {(p.ratingAvg ?? p.rating) !== undefined && (
+                        <div className="flex items-center gap-1 mt-1">
+                          <Star className="h-4 w-4 text-amber-500 fill-amber-500" />
+                          <span className="text-sm font-semibold text-slate-700">
+                            {(p.ratingAvg ?? p.rating)!.toFixed(1)}
+                          </span>
+                        </div>
+                      )}
+                    </div>
                   </div>
-                )}
-                <div className="min-w-0 flex-1">
-                  <p className="font-bold text-slate-900 truncate">
-                    {p.businessName || p.fullName || "Unknown"}
-                  </p>
-                  {(p.ratingAvg ?? p.rating) !== undefined && (
-                    <div className="flex items-center gap-1 mt-1">
-                      <Star className="h-4 w-4 text-amber-500 fill-amber-500" />
-                      <span className="text-sm font-semibold text-slate-700">
-                        {(p.ratingAvg ?? p.rating)!.toFixed(1)}
-                      </span>
+
+                  {(p.serviceCategory || p.description) && (
+                    <p className="text-sm text-slate-500 font-medium line-clamp-2 mb-3">
+                      {p.serviceCategory || p.description}
+                    </p>
+                  )}
+
+                  {p.location && (
+                    <div className="flex items-center gap-1 text-xs text-slate-400 font-medium">
+                      <MapPin className="h-3.5 w-3.5" />
+                      {p.location}
                     </div>
                   )}
-                </div>
-              </div>
-              {(p.serviceCategory || p.description) && (
-                <p className="text-sm text-slate-500 font-medium line-clamp-2">
-                  {p.serviceCategory || p.description}
-                </p>
-              )}
-            </button>
-          ))}
-        </div>
+                </button>
+              ))}
+            </div>
 
-        {providers.length === 0 && (
-          <p className="text-center text-slate-500 font-medium py-12">No providers found.</p>
+            {providers.length === 0 && (
+              <p className="text-center text-slate-500 font-medium py-12">
+                No providers found. Try adjusting your search.
+              </p>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/services/profile.ts
+++ b/frontend/src/services/profile.ts
@@ -39,6 +39,7 @@ export type BackendProvider = {
   verified?: boolean;
   availabilityStatus?: string;
   description?: string;
+  location?: string;
 };
 
 export type GetMeResponse = (BackendUser & { type: 'user' }) | (BackendProvider & { type: 'provider' });

--- a/frontend/src/services/search.ts
+++ b/frontend/src/services/search.ts
@@ -1,0 +1,136 @@
+import fetchApi from '../lib/api';
+import type { ApiResponse } from '../lib/api';
+import type { BackendProvider } from './profile';
+
+// ─── Param types ──────────────────────────────────────────────────────────────
+
+export interface SearchProvidersParams {
+  keyword?: string;
+  category?: string;
+  location?: string;
+  minRating?: number;
+  page?: number;
+  limit?: number;
+}
+
+export interface SearchServicesParams {
+  keyword?: string;
+  category?: string;
+  location?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  page?: number;
+  limit?: number;
+}
+
+// ─── Response types ───────────────────────────────────────────────────────────
+
+export interface BackendService {
+  _id: string;
+  providerId: string;
+  categoryId: string | { _id: string; name: string };
+  name: string;
+  description: string;
+  basePrice: number;
+  durationMinutes: number;
+  location?: string;
+  isActive: boolean;
+}
+
+export interface SearchProvidersResult {
+  providers: BackendProvider[];
+  total: number;
+  page: number;
+  count: number;
+}
+
+export interface SearchServicesResult {
+  services: BackendService[];
+  total: number;
+  page: number;
+  count: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildQuery(params: Record<string, string | number | undefined>): string {
+  const qs = new URLSearchParams();
+  for (const [key, val] of Object.entries(params)) {
+    if (val !== undefined && val !== '') qs.set(key, String(val));
+  }
+  const str = qs.toString();
+  return str ? `?${str}` : '';
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export const searchService = {
+  /**
+   * Search providers by keyword, category, and/or location.
+   * Maps to GET /api/providers/search
+   */
+  async searchProviders(
+    params: SearchProvidersParams
+  ): Promise<ApiResponse<SearchProvidersResult>> {
+    const query = buildQuery({
+      search: params.keyword,
+      category: params.category,
+      location: params.location,
+      minRating: params.minRating,
+      page: params.page,
+      limit: params.limit,
+    });
+
+    // API returns: { success, count, total, page, data: { providers: [...] } }
+    // fetchApi unwraps to data.data → { providers: [...] }
+    const res = await fetchApi<{ providers: BackendProvider[]; total?: number; page?: number; count?: number }>(
+      `/providers/search${query}`
+    );
+
+    if (!res.success) return { success: false, error: res.error };
+
+    return {
+      success: true,
+      data: {
+        providers: res.data?.providers ?? [],
+        total: res.data?.total ?? 0,
+        page: res.data?.page ?? 1,
+        count: res.data?.count ?? 0,
+      },
+    };
+  },
+
+  /**
+   * Search services by keyword, category, and/or location.
+   * Maps to GET /api/services
+   */
+  async searchServices(
+    params: SearchServicesParams
+  ): Promise<ApiResponse<SearchServicesResult>> {
+    const query = buildQuery({
+      search: params.keyword,
+      category: params.category,
+      location: params.location,
+      minPrice: params.minPrice,
+      maxPrice: params.maxPrice,
+      page: params.page,
+      limit: params.limit,
+    });
+
+    // API returns: { success, count, total, page, data: [...] }
+    // fetchApi unwraps to data.data → [...]
+    const res = await fetchApi<BackendService[]>(`/services${query}`);
+
+    if (!res.success) return { success: false, error: res.error };
+
+    return {
+      success: true,
+      data: {
+        services: Array.isArray(res.data) ? res.data : [],
+        total: 0,
+        page: 1,
+        count: Array.isArray(res.data) ? res.data.length : 0,
+      },
+    };
+  },
+};

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/__tests__/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                                  
  - **Backend**: Added `location` field to `Provider` and `Service` models; `GET /api/providers/search` and `GET /api/services` now accept `?keyword`, `?location`, and `?category` query       params with case-insensitive regex matching                                                                                                                                                   - **Frontend**: Wired `ProvidersList` to `GET /api/providers/search` via a new `searchService`; `SearchBar` component with keyword, location, and category inputs; text inputs debounced at
  400ms via `useDebounce` hook                                                                                                                                                                  - **Tests**: 21 backend integration tests covering all filter combinations; 33 frontend unit tests across `useDebounce`, `searchService`, and `SearchBar`; fixed `emailService.js` lazy       Resend init so missing `RESEND_API_KEY` in CI no longer crashes test suites
                                                                                                                                                                                                ## Commits
                                                                                                                                                                                                | # | Scope | What |
  |---|-------|------|                                                                                                                                                                          | 1 | `feat(models)` | Add `location` field to Provider & Service schemas |
  | 2 | `feat(api)` | Location filter on `/api/providers/search` and `/api/services` |                                                                                                          | 3 | `test(backend)` | 21 integration tests for search & filter endpoints |                                                                                                                  | 4 | `feat(frontend)` | `useDebounce` hook + `searchService` layer |
  | 5 | `feat(frontend)` | `SearchBar` component + wire up `ProvidersList` |                                                                                                                    | 6 | `test(frontend)` | Vitest setup + 33 unit tests |
  | 7 | `fix(ci)` | Lazy-init Resend client + commit frontend lockfile |                                                                                                                                                                                                                                                                                                                      ## Test plan                                                                                                                                                                                                                                                                                                                                                                                - [ ] `cd backend && npm test` — 57 tests, all pass                                                                                                                                           - [ ] `cd frontend && npm test` — 33 tests, all pass                                                                                                                                          - [ ] `cd frontend && npm run build` — no errors
  - [x] Manual: visit `/providers`, type keyword/location — results update after 400ms debounce; category dropdown filters immediately; "Clear filters" resets all inputs     