### PR TITLE
Fix/deep qa

### DIFF
--- a/backend/src/controllers/bookingController.js
+++ b/backend/src/controllers/bookingController.js
@@ -147,6 +147,37 @@ export const getBooking = async (req, res) => {
 
 export const acceptBooking = async (req, res) => {
   try {
+    // Resolve the requesting provider's internal id
+    const internalUser = await getInternalUser(req.user.id);
+    if (!internalUser) {
+      return res.status(404).json({ success: false, error: 'User not found' });
+    }
+
+    const { data: provider } = await supabase
+      .from('providers')
+      .select('id')
+      .eq('user_id', internalUser.id)
+      .single();
+
+    if (!provider) {
+      return res.status(404).json({ success: false, error: 'Provider profile not found. Complete your provider profile setup first' });
+    }
+
+    // Fetch booking and verify ownership before updating
+    const { data: existing } = await supabase
+      .from('bookings')
+      .select('id, provider_id, status')
+      .eq('id', req.params.id)
+      .single();
+
+    if (!existing) {
+      return res.status(404).json({ success: false, error: 'Booking not found' });
+    }
+
+    if (existing.provider_id !== provider.id) {
+      return res.status(403).json({ success: false, error: 'Not authorized to accept this booking' });
+    }
+
     const { data: booking, error } = await supabase
       .from('bookings')
       .update({ status: 'confirmed' })
@@ -155,7 +186,7 @@ export const acceptBooking = async (req, res) => {
       .single();
 
     if (error || !booking) {
-      return res.status(404).json({ success: false, error: 'Booking not found' });
+      return res.status(400).json({ success: false, error: error?.message || 'Failed to update booking' });
     }
 
     res.json({ success: true, data: booking });

--- a/backend/src/controllers/bookingController.js
+++ b/backend/src/controllers/bookingController.js
@@ -199,6 +199,41 @@ export const acceptBooking = async (req, res) => {
 
 export const rejectBooking = async (req, res) => {
   try {
+    // Resolve the requesting provider's internal id
+    const internalUser = await getInternalUser(req.user.id);
+    if (!internalUser) {
+      return res.status(404).json({ success: false, error: 'User not found' });
+    }
+
+    const { data: provider } = await supabase
+      .from('providers')
+      .select('id')
+      .eq('user_id', internalUser.id)
+      .single();
+
+    if (!provider) {
+      return res.status(404).json({ success: false, error: 'Provider profile not found. Complete your provider profile setup first' });
+    }
+
+    // Fetch booking and verify ownership + status before updating
+    const { data: existing } = await supabase
+      .from('bookings')
+      .select('id, provider_id, status')
+      .eq('id', req.params.id)
+      .single();
+
+    if (!existing) {
+      return res.status(404).json({ success: false, error: 'Booking not found' });
+    }
+
+    if (existing.provider_id !== provider.id) {
+      return res.status(403).json({ success: false, error: 'Not authorized to reject this booking' });
+    }
+
+    if (existing.status !== 'pending' && existing.status !== 'confirmed') {
+      return res.status(400).json({ success: false, error: `Cannot reject a booking with status '${existing.status}'` });
+    }
+
     const { data: booking, error } = await supabase
       .from('bookings')
       .update({
@@ -210,7 +245,7 @@ export const rejectBooking = async (req, res) => {
       .single();
 
     if (error || !booking) {
-      return res.status(404).json({ success: false, error: 'Booking not found' });
+      return res.status(400).json({ success: false, error: error?.message || 'Failed to update booking' });
     }
 
     res.json({ success: true, data: booking });

--- a/backend/src/controllers/bookingController.js
+++ b/backend/src/controllers/bookingController.js
@@ -100,7 +100,7 @@ export const listBookings = async (req, res) => {
         .single();
 
       if (!provider) {
-        return res.status(404).json({ success: false, error: 'Provider profile not found' });
+        return res.status(404).json({ success: false, error: 'Provider profile not found. Complete your provider profile setup first' });
       }
       query = query.eq('provider_id', provider.id);
     } else {

--- a/backend/src/controllers/bookingController.js
+++ b/backend/src/controllers/bookingController.js
@@ -43,7 +43,7 @@ export const createBooking = async (req, res) => {
         scheduled_at,
         notes:            notes || null,
         total_price:      service?.base_price || 0,
-        status:           'confirmed',
+        status:           'pending',
         payment_status:   'pending',
         address_street:   address_street || null,
         address_city:     address_city   || null,

--- a/backend/src/controllers/bookingController.js
+++ b/backend/src/controllers/bookingController.js
@@ -256,4 +256,63 @@ export const rejectBooking = async (req, res) => {
   }
 };
 
-export default { createBooking, listBookings, getBooking, acceptBooking, rejectBooking };
+export const completeBooking = async (req, res) => {
+  try {
+    // Resolve the requesting provider's internal id
+    const internalUser = await getInternalUser(req.user.id);
+    if (!internalUser) {
+      return res.status(404).json({ success: false, error: 'User not found' });
+    }
+
+    const { data: provider } = await supabase
+      .from('providers')
+      .select('id')
+      .eq('user_id', internalUser.id)
+      .single();
+
+    if (!provider) {
+      return res.status(404).json({ success: false, error: 'Provider profile not found. Complete your provider profile setup first' });
+    }
+
+    // Fetch booking and verify ownership + status
+    const { data: existing } = await supabase
+      .from('bookings')
+      .select('id, provider_id, status')
+      .eq('id', req.params.id)
+      .single();
+
+    if (!existing) {
+      return res.status(404).json({ success: false, error: 'Booking not found' });
+    }
+
+    if (existing.provider_id !== provider.id) {
+      return res.status(403).json({ success: false, error: 'Not authorized to complete this booking' });
+    }
+
+    if (existing.status !== 'confirmed') {
+      return res.status(400).json({ success: false, error: 'Can only complete confirmed bookings' });
+    }
+
+    const { data: booking, error } = await supabase
+      .from('bookings')
+      .update({
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', req.params.id)
+      .select()
+      .single();
+
+    if (error || !booking) {
+      return res.status(400).json({ success: false, error: error?.message || 'Failed to update booking' });
+    }
+
+    res.json({ success: true, data: booking });
+
+  } catch (err) {
+    console.error('Complete booking error:', err);
+    res.status(500).json({ success: false, error: 'Failed to complete booking' });
+  }
+};
+
+export default { createBooking, listBookings, getBooking, acceptBooking, rejectBooking, completeBooking };

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -44,17 +44,7 @@ export const createReview = async (req, res) => {
       return res.status(400).json({ success: false, error: 'Can only review completed bookings' });
     }
 
-    // Check review doesn't already exist — booking_id is UNIQUE in reviews table
-    const { data: existing } = await supabase
-      .from('reviews')
-      .select('id')
-      .eq('booking_id', booking_id)
-      .single();
-
-    if (existing) {
-      return res.status(400).json({ success: false, error: 'You have already reviewed this booking' });
-    }
-
+    // INSERT directly and let the UNIQUE constraint on booking_id catch duplicates atomically
     const { data: review, error } = await supabase
       .from('reviews')
       .insert({
@@ -67,7 +57,12 @@ export const createReview = async (req, res) => {
       .select()
       .single();
 
-    if (error) return res.status(400).json({ success: false, error: error.message });
+    if (error) {
+      if (error.code === '23505') {
+        return res.status(400).json({ success: false, error: 'You have already reviewed this booking' });
+      }
+      return res.status(400).json({ success: false, error: error.message });
+    }
 
     // Update provider rating average
     await updateProviderRating(booking.provider_id);

--- a/backend/src/routes/bookingRoutes.js
+++ b/backend/src/routes/bookingRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { createBooking, listBookings, getBooking, acceptBooking, rejectBooking }
+import { createBooking, listBookings, getBooking, acceptBooking, rejectBooking, completeBooking }
   from '../controllers/bookingController.js';
 import { authenticate, requireRole } from '../middleware/authMiddleware.js';
  
@@ -11,7 +11,8 @@ router.use(authenticate);
 router.get('/',          listBookings);
 router.get('/:id',       getBooking);
 router.post('/',         requireRole('customer'), createBooking);
-router.put('/:id/accept', requireRole('provider'), acceptBooking);
-router.put('/:id/reject', requireRole('provider'), rejectBooking);
+router.put('/:id/accept',    requireRole('provider'), acceptBooking);
+router.put('/:id/reject',    requireRole('provider'), rejectBooking);
+router.put('/:id/complete',  requireRole('provider'), completeBooking);
  
 export default router;

--- a/frontend/src/components/SupportModal.tsx
+++ b/frontend/src/components/SupportModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { X, MessageSquare, Loader2 } from "lucide-react";
+import fetchApi from "../lib/api";
 
 type UserRole = "customer" | "provider";
 type Priority = "LOW" | "MEDIUM" | "HIGH";
@@ -64,9 +65,8 @@ export const SupportModal: React.FC<SupportModalProps> = ({
     setError(null);
 
     try {
-      const response = await fetch("http://localhost:3000/api/complaints", {
+      const result = await fetchApi("/complaints", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           userId,
           subject,
@@ -75,16 +75,15 @@ export const SupportModal: React.FC<SupportModalProps> = ({
         }),
       });
 
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || "Failed to submit. Please try again.");
+      if (!result.success) {
+        setError(result.error || "Failed to submit. Please try again.");
+      } else {
+        setSubmitted(true);
       }
-
-      setSubmitted(true);
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Something went wrong";
-      console.error(message);
+      setError(message);
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## Summary

- **SC-01** — SupportModal: replace hardcoded `fetch('http://localhost:3000/api/complaints')` with `fetchApi('/complaints')` from `lib/api.ts`; adds auth token, sets error state on failure
- **SC-02** — `acceptBooking`: resolve provider via getInternalUser → providers table, assert `booking.provider_id === provider.id`, return 403 on mismatch
- **SC-03** — `rejectBooking`: same ownership check as SC-02 + assert status is `pending`/`confirmed` before cancelling; 400 for terminal statuses
- **SC-04** — `createBooking`: change `status: 'confirmed'` → `status: 'pending'` to restore the pending→accept/reject lifecycle
- **SC-05** — Add `completeBooking` (`PUT /bookings/:id/complete`, provider role): ownership + status guard, updates to `completed` with `completed_at` — unblocks review creation
- **SC-06** — `listBookings`: clarify 404 message to `'Provider profile not found. Complete your provider profile setup first'`
- **SC-07** — `createReview`: drop SELECT-then-INSERT race; INSERT directly and catch Postgres error code `23505` atomically

## Note on pre-existing TS errors
`App.tsx`, `Profile.tsx`, `ProvidersList.tsx`, `UsersList.tsx` have naming errors from the MongoDB→Supabase migration — not introduced by this PR.

## Test plan
- [ ] POST /api/bookings → status: 'pending'
- [ ] PUT /bookings/:id/accept with wrong provider → 403
- [ ] PUT /bookings/:id/accept with correct provider → 200 confirmed
- [ ] PUT /bookings/:id/reject with wrong provider → 403
- [ ] PUT /bookings/:id/reject on cancelled booking → 400
- [ ] PUT /bookings/:id/complete → 200 completed
- [ ] POST /api/reviews on completed booking → 201
- [ ] POST /api/reviews again → 400 duplicate
- [ ] SupportModal Network tab: Authorization header present, no localhost:3000
