### PR TITLE
fix: add pagination count to searchProviders (Issue #54)

### DIFF
--- a/backend/src/controllers/providerController.js
+++ b/backend/src/controllers/providerController.js
@@ -152,7 +152,7 @@ export const searchProviders = async (req, res) => {
         id, business_name, description, rating_avg, rating_count, is_active,
         user:users(full_name, email, avatar_url),
         provider_categories(category_id)
-      `);
+      `, { count: 'exact' });
 
     if (categoryProviderIds) query = query.in('id', categoryProviderIds);
 


### PR DESCRIPTION
## Summary
- Adds `{ count: 'exact' }` option to the `.select()` call in `searchProviders`
- Without this, PostgREST never populates the `count` field, so paginated API responses always returned `total: null`

## Changes
- `backend/src/controllers/providerController.js`: 1-line fix on the `searchProviders` query

## Testing
- `GET /api/providers?page=1&limit=10` now returns a non-null `total` field in the response