### PR TITLE
feat(SER-123): show reviews on provider profile + fix unreachable reviews API

### DIFF
--- a/backend/src/routes/reviewRoutes.js
+++ b/backend/src/routes/reviewRoutes.js
@@ -1,0 +1,13 @@
+import express from 'express';
+import { createReview, getProviderReviews } from '../controllers/reviewController.js';
+import { authenticate } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+// Public — anyone can read reviews for a provider
+router.get('/:providerId', getProviderReviews);
+
+// Authenticated — only logged-in customers can submit a review
+router.post('/', authenticate, createReview);
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ import profileRoutes from './routes/profileRoutes.js';
 import providerRoutes from './routes/providerRoutes.js';
 import bookingRoutes from './routes/bookingRoutes.js';
 import complaintRoutes from './routes/complaintRoutes.js';
+import reviewRoutes from './routes/reviewRoutes.js';
 import authRoutes from './routes/authRoutes.js';
 // import userRoutes from './routes/userRoutes.js';
 import testRoutes from './routes/testRoutes.js';
@@ -49,6 +50,7 @@ app.use('/api/users', profileRoutes);
 app.use('/api/services', serviceRoutes);
 app.use('/api/providers', providerRoutes);
 app.use('/api/bookings', bookingRoutes);
+app.use('/api/reviews', reviewRoutes);
 app.use('/api/complaints', complaintRoutes);
 // Mount test routes in development only — never in production
 if (process.env.NODE_ENV !== 'production') {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -167,30 +167,27 @@ useEffect(() => {
       const supabaseUser = data?.user;
 
       if (!accessToken) {
-        return {
-          success: false,
-          message: "Login failed — no session returned",
-        };
+        return { success: false, message: "Login failed — no session returned" };
       }
 
-      const name =
-        supabaseUser?.email?.split("@")[0] || email.split("@")[0];
+      const name = supabaseUser?.email?.split("@")[0] || email.split("@")[0];
       const avatar = `https://ui-avatars.com/api/?name=${encodeURIComponent(name)}&background=0F172A&color=fff`;
 
       let profile = null;
-      try {
-        const resp = await fetch(`${API_BASE}/api/users/me`, {
-          headers: { Authorization: `Bearer ${accessToken}` },
-        });
-        if (!resp.ok) {
-          const text = await resp.text();
-          console.error("Profile fetch failed", resp.status, text);
-        } else {
-          const json = await resp.json();
-          if (json?.success) profile = json.data;
+      if (accessToken) {
+        try {
+          const resp = await fetch(`${API_BASE}/api/users/me`, {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          });
+          if (!resp.ok) {
+            console.error("Profile fetch failed", resp.status);
+          } else {
+            const json = await resp.json();
+            if (json?.success) profile = json.data;
+          }
+        } catch (fetchErr) {
+          console.error("Profile fetch error:", fetchErr);
         }
-      } catch (fetchErr) {
-        console.error("Profile fetch error:", fetchErr);
       }
 
       const userData = {
@@ -221,9 +218,7 @@ useEffect(() => {
     } catch (err) {
       console.error("Login failed", err);
       const message =
-        err instanceof Error
-          ? err.message
-          : "Login failed. Please try again.";
+        err instanceof Error ? err.message : "Login failed. Please try again.";
       return { success: false, message };
     }
   };
@@ -323,7 +318,7 @@ useEffect(() => {
 
     if (bookServiceId) {
       return (
-        <ServiceProviders serviceId={bookServiceId} onNavigate={navigate} />
+        <ServiceProviders serviceId={bookServiceId} onNavigate={navigate} user={user} />
       );
     }
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { profileService } from "../services/profile";
 import type { BackendUser, BackendProvider } from "../services/profile";
+import fetchApi from "../lib/api";
 import {
   User as UserIcon,
   Mail,
@@ -9,7 +10,16 @@ import {
   Loader2,
   Star,
   Briefcase,
+  MessageSquare,
 } from "lucide-react";
+
+interface Review {
+  id: string;
+  rating: number;
+  comment: string | null;
+  created_at: string;
+  reviewer: { full_name: string; avatar_url: string | null } | null;
+}
 
 interface ProfileProps {
   profileId: string;
@@ -31,6 +41,8 @@ export const Profile: React.FC<ProfileProps> = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [reviewsLoading, setReviewsLoading] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -132,6 +144,23 @@ export const Profile: React.FC<ProfileProps> = ({
       cancelled = true;
     };
   }, [profileId, initialType, currentUser, currentUser?.email]);
+
+  // Fetch reviews when a provider profile loads
+  useEffect(() => {
+    if (!profile || profile.type !== "provider") return;
+    const providerId = profile.data.id;
+    if (!providerId) return;
+
+    setReviewsLoading(true);
+    fetchApi<{ count: number; data: Review[] }>(`/reviews/${providerId}`)
+      .then((res) => {
+        if (res.success && res.data) {
+          const payload = res.data as unknown as { count: number; data: Review[] };
+          setReviews(Array.isArray(payload.data) ? payload.data : []);
+        }
+      })
+      .finally(() => setReviewsLoading(false));
+  }, [profile]);
 
   const getRoleLabel = (role: string) => {
     switch (role?.toLowerCase()) {
@@ -338,6 +367,89 @@ export const Profile: React.FC<ProfileProps> = ({
                     ID
                   </p>
                   <p className="text-slate-500 text-sm font-mono">{data.id}</p>
+                </div>
+              )}
+
+              {/* Reviews section — provider profiles only */}
+              {isProvider && (
+                <div className="pt-2">
+                  <div className="flex items-center gap-2 mb-4">
+                    <MessageSquare className="h-5 w-5 text-slate-400" />
+                    <h2 className="text-sm font-bold text-slate-400 uppercase tracking-wider">
+                      Reviews
+                      {reviews.length > 0 && (
+                        <span className="ml-2 normal-case font-semibold text-slate-500">
+                          ({reviews.length})
+                        </span>
+                      )}
+                    </h2>
+                  </div>
+
+                  {reviewsLoading && (
+                    <div className="flex justify-center py-6">
+                      <Loader2 className="h-6 w-6 text-teal-500 animate-spin" />
+                    </div>
+                  )}
+
+                  {!reviewsLoading && reviews.length === 0 && (
+                    <div className="flex flex-col items-center justify-center py-8 text-center bg-slate-50 rounded-2xl">
+                      <Star className="h-8 w-8 text-slate-200 mb-2" />
+                      <p className="text-slate-500 font-medium text-sm">No reviews yet</p>
+                      <p className="text-slate-400 text-xs mt-1">Reviews appear here after completed bookings.</p>
+                    </div>
+                  )}
+
+                  {!reviewsLoading && reviews.length > 0 && (
+                    <div className="space-y-3">
+                      {reviews.map((review) => (
+                        <div key={review.id} className="p-4 bg-slate-50 rounded-2xl space-y-2">
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="flex items-center gap-2">
+                              {review.reviewer?.avatar_url ? (
+                                <img
+                                  src={review.reviewer.avatar_url}
+                                  alt={review.reviewer.full_name}
+                                  className="h-8 w-8 rounded-full object-cover flex-shrink-0"
+                                />
+                              ) : (
+                                <div className="h-8 w-8 rounded-full bg-slate-200 flex items-center justify-center flex-shrink-0">
+                                  <UserIcon className="h-4 w-4 text-slate-400" />
+                                </div>
+                              )}
+                              <span className="text-sm font-semibold text-slate-700">
+                                {review.reviewer?.full_name ?? "Anonymous"}
+                              </span>
+                            </div>
+                            <div className="flex items-center gap-0.5 shrink-0">
+                              {Array.from({ length: 5 }).map((_, i) => (
+                                <Star
+                                  key={i}
+                                  size={13}
+                                  className={
+                                    i < review.rating
+                                      ? "fill-amber-400 text-amber-400"
+                                      : "text-slate-200 fill-slate-200"
+                                  }
+                                />
+                              ))}
+                            </div>
+                          </div>
+                          {review.comment && (
+                            <p className="text-sm text-slate-600 leading-relaxed">
+                              {review.comment}
+                            </p>
+                          )}
+                          <p className="text-xs text-slate-400">
+                            {new Date(review.created_at).toLocaleDateString("en-US", {
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                            })}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -151,15 +151,21 @@ export const Profile: React.FC<ProfileProps> = ({
     const providerId = profile.data.id;
     if (!providerId) return;
 
-    setReviewsLoading(true);
-    fetchApi<{ count: number; data: Review[] }>(`/reviews/${providerId}`)
-      .then((res) => {
-        if (res.success && res.data) {
+    let cancelled = false;
+    const loadReviews = async () => {
+      setReviewsLoading(true);
+      try {
+        const res = await fetchApi<{ count: number; data: Review[] }>(`/reviews/${providerId}`);
+        if (!cancelled && res.success && res.data) {
           const payload = res.data as unknown as { count: number; data: Review[] };
           setReviews(Array.isArray(payload.data) ? payload.data : []);
         }
-      })
-      .finally(() => setReviewsLoading(false));
+      } finally {
+        if (!cancelled) setReviewsLoading(false);
+      }
+    };
+    loadReviews();
+    return () => { cancelled = true; };
   }, [profile]);
 
   const getRoleLabel = (role: string) => {

--- a/frontend/src/pages/ServiceProviders.tsx
+++ b/frontend/src/pages/ServiceProviders.tsx
@@ -97,7 +97,7 @@ const ProviderSkeleton: React.FC = () => (
 export const ServiceProviders: React.FC<ServiceProvidersProps> = ({
   serviceId,
   onNavigate,
-  user,
+  user: _user, // reserved for role-based Book button once booking UI ships
 }) => {
   const [service, setService] = useState<ServiceDetail | null>(null);
   const [providers, setProviders] = useState<ProviderCard[]>([]);

--- a/frontend/src/pages/ServiceProviders.tsx
+++ b/frontend/src/pages/ServiceProviders.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { ArrowLeft, Star, DollarSign, Clock } from "lucide-react";
+import { ArrowLeft, Star, DollarSign, Clock, ExternalLink } from "lucide-react";
 
 interface ServiceDetail {
   id: string;
@@ -55,6 +55,7 @@ function normalizeProviderCard(raw: Record<string, unknown>): ProviderCard {
 interface ServiceProvidersProps {
   serviceId: string;
   onNavigate: (path: string) => void;
+  user?: { role?: string } | null;
 }
 
 const CATEGORY_ICONS: Record<string, string> = {
@@ -96,6 +97,7 @@ const ProviderSkeleton: React.FC = () => (
 export const ServiceProviders: React.FC<ServiceProvidersProps> = ({
   serviceId,
   onNavigate,
+  user,
 }) => {
   const [service, setService] = useState<ServiceDetail | null>(null);
   const [providers, setProviders] = useState<ProviderCard[]>([]);
@@ -278,17 +280,26 @@ export const ServiceProviders: React.FC<ServiceProvidersProps> = ({
                 )}
               </div>
 
-              {/* Book button — disabled, coming soon */}
-              <div className="relative group/btn">
+              {/* Action buttons */}
+              <div className="flex gap-2 mt-auto">
                 <button
-                  disabled
-                  className="w-full py-2.5 rounded-xl bg-teal-50 text-teal-400 font-semibold text-sm border border-teal-100 cursor-not-allowed"
+                  onClick={() => onNavigate(`/profile/${provider.id}?type=provider`)}
+                  className="flex-1 flex items-center justify-center gap-1.5 py-2.5 rounded-xl bg-slate-50 text-slate-600 font-semibold text-sm border border-slate-100 hover:bg-slate-100 transition-colors"
                 >
-                  Book with Provider
+                  <ExternalLink size={13} />
+                  View Profile
                 </button>
-                <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-slate-900 text-white text-[10px] font-semibold rounded-md whitespace-nowrap opacity-0 group-hover/btn:opacity-100 transition-opacity pointer-events-none">
-                  Coming Soon
-                </span>
+                <div className="relative group/btn flex-1">
+                  <button
+                    disabled
+                    className="w-full py-2.5 rounded-xl bg-teal-50 text-teal-400 font-semibold text-sm border border-teal-100 cursor-not-allowed"
+                  >
+                    Book
+                  </button>
+                  <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-slate-900 text-white text-[10px] font-semibold rounded-md whitespace-nowrap opacity-0 group-hover/btn:opacity-100 transition-opacity pointer-events-none">
+                    Coming Soon
+                  </span>
+                </div>
               </div>
             </div>
           ))}

--- a/frontend/src/pages/ServiceProviders.tsx
+++ b/frontend/src/pages/ServiceProviders.tsx
@@ -97,7 +97,6 @@ const ProviderSkeleton: React.FC = () => (
 export const ServiceProviders: React.FC<ServiceProvidersProps> = ({
   serviceId,
   onNavigate,
-  user: _user, // reserved for role-based Book button once booking UI ships
 }) => {
   const [service, setService] = useState<ServiceDetail | null>(null);
   const [providers, setProviders] = useState<ProviderCard[]>([]);


### PR DESCRIPTION
## Summary
- **Bug fix**: `reviewRoutes.js` existed on disk but was never committed and never mounted — the entire `/api/reviews` API was unreachable. This PR fixes that.
- **SER-147**: `GET /api/reviews/:providerId` is now reachable and returns paginated reviews with reviewer info
- **SER-149/150/151**: Provider profile page now renders a reviews section (stars, reviewer name/avatar, comment, date, empty state)
- **SER-113 UI**: "View Profile" button added next to the disabled Book button on the ServiceProviders page

## Changes
- `backend/src/routes/reviewRoutes.js`: first-ever commit of this file (was untracked)
- `backend/src/server.js`: mount `reviewRoutes` at `/api/reviews`
- `frontend/src/pages/Profile.tsx`: fetch and render reviews for provider profiles
- `frontend/src/pages/ServiceProviders.tsx`: add "View Profile" navigation button
- `frontend/src/App.tsx`: pass `user` prop to `ServiceProviders`

## Test plan
- [ ] `GET /api/reviews/:providerId` returns `{ success: true, data: [] }` for a provider with no reviews
- [ ] Provider profile page shows "No reviews yet" empty state
- [ ] After inserting a review in Supabase, the profile shows the review card with stars, name, and comment
- [ ] "View Profile" button on ServiceProviders page navigates to `/profile/:id?type=provider`