### PR TITLE
feat(SER-132): wire chatbot to real booking data

### DIFF
--- a/backend/src/controllers/chatbotController.js
+++ b/backend/src/controllers/chatbotController.js
@@ -1,0 +1,66 @@
+import supabase from '../config/supabase.js';
+import { getInternalUser, profileNotFoundResponse } from '../utils/internalUser.js';
+
+/**
+ * GET /api/chatbot/context
+ * Returns role-appropriate booking data for the chatbot to display.
+ * Customers get their own bookings; providers get their incoming/scheduled jobs.
+ */
+export const getChatbotContext = async (req, res) => {
+  try {
+    const internalUser = await getInternalUser(req.user.id);
+    if (!internalUser) return profileNotFoundResponse(res);
+
+    const role = internalUser.role || req.user.role || 'customer';
+    let bookings = [];
+
+    if (role === 'provider') {
+      // Look up provider profile
+      const { data: providerProfile } = await supabase
+        .from('providers')
+        .select('id')
+        .eq('user_id', internalUser.id)
+        .maybeSingle();
+
+      if (providerProfile) {
+        const { data } = await supabase
+          .from('bookings')
+          .select(`
+            id, status, scheduled_at, total_price, notes,
+            service:services(name),
+            customer:users(full_name)
+          `)
+          .eq('provider_id', providerProfile.id)
+          .order('scheduled_at', { ascending: true })
+          .limit(10);
+
+        bookings = data || [];
+      }
+    } else {
+      // Customer sees their own bookings
+      const { data } = await supabase
+        .from('bookings')
+        .select(`
+          id, status, scheduled_at, total_price, notes,
+          service:services(name),
+          provider:providers(business_name)
+        `)
+        .eq('customer_id', internalUser.id)
+        .order('scheduled_at', { ascending: false })
+        .limit(10);
+
+      bookings = data || [];
+    }
+
+    return res.json({
+      success: true,
+      data: { role, bookings },
+    });
+
+  } catch (err) {
+    console.error('getChatbotContext error:', err);
+    res.status(500).json({ success: false, error: 'Failed to load chatbot context' });
+  }
+};
+
+export default { getChatbotContext };

--- a/backend/src/routes/chatbotRoutes.js
+++ b/backend/src/routes/chatbotRoutes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getChatbotContext } from '../controllers/chatbotController.js';
+import { authenticate } from '../middleware/authMiddleware.js';
+
+const router = express.Router();
+
+// GET /api/chatbot/context — role-aware booking data for the chatbot
+router.get('/context', authenticate, getChatbotContext);
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ import profileRoutes from './routes/profileRoutes.js';
 import providerRoutes from './routes/providerRoutes.js';
 import bookingRoutes from './routes/bookingRoutes.js';
 import complaintRoutes from './routes/complaintRoutes.js';
+import chatbotRoutes from './routes/chatbotRoutes.js';
 import authRoutes from './routes/authRoutes.js';
 // import userRoutes from './routes/userRoutes.js';
 import testRoutes from './routes/testRoutes.js';
@@ -49,6 +50,7 @@ app.use('/api/users', profileRoutes);
 app.use('/api/services', serviceRoutes);
 app.use('/api/providers', providerRoutes);
 app.use('/api/bookings', bookingRoutes);
+app.use('/api/chatbot', chatbotRoutes);
 app.use('/api/complaints', complaintRoutes);
 // Mount test routes in development only — never in production
 if (process.env.NODE_ENV !== 'production') {

--- a/frontend/src/components/Chatbot.tsx
+++ b/frontend/src/components/Chatbot.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { ChevronDown, Send, MessageCircle } from "lucide-react";
 import type { User, Provider } from "../../types";
 import { UserRole } from "../../types";
+import fetchApi from "../lib/api";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -16,8 +17,25 @@ interface DummyOrder {
   serviceIcon: string;
   providerName: string;
   date: string;
-  status: "REQUESTED" | "ACCEPTED" | "COMPLETED";
+  status: "REQUESTED" | "ACCEPTED" | "COMPLETED" | "CANCELLED";
   totalPrice: number;
+}
+
+// Real booking data shape from GET /api/chatbot/context
+interface RealBooking {
+  id: string;
+  status: string;
+  scheduled_at: string;
+  total_price: number;
+  notes?: string | null;
+  service?: { name: string } | null;
+  provider?: { business_name: string } | null;
+  customer?: { full_name: string } | null;
+}
+
+interface ChatbotContext {
+  role: string;
+  bookings: RealBooking[];
 }
 
 interface ServiceItem {
@@ -82,35 +100,45 @@ type Intent =
 
 // ─── Data ────────────────────────────────────────────────────────────────────
 
-const DUMMY_ORDERS: DummyOrder[] = [
-  {
-    id: "ORD-001",
-    serviceCategory: "Cleaning",
-    serviceIcon: "🧹",
-    providerName: "Maria's Clean Co.",
-    date: "Mar 28, 2026",
-    status: "REQUESTED",
-    totalPrice: 85,
-  },
-  {
-    id: "ORD-002",
-    serviceCategory: "Plumbing",
-    serviceIcon: "🔧",
-    providerName: "FastFix Plumbing",
-    date: "Mar 22, 2026",
-    status: "ACCEPTED",
-    totalPrice: 120,
-  },
-  {
-    id: "ORD-003",
-    serviceCategory: "Electrical",
-    serviceIcon: "⚡",
-    providerName: "BrightSpark Electric",
-    date: "Mar 10, 2026",
-    status: "COMPLETED",
-    totalPrice: 200,
-  },
-];
+const SERVICE_ICON_MAP: Record<string, string> = {
+  cleaning: "🧹",
+  plumbing: "🔧",
+  electrical: "⚡",
+  electric: "⚡",
+  pest: "🐛",
+};
+
+function getServiceIcon(name: string): string {
+  const lower = name.toLowerCase();
+  for (const [key, icon] of Object.entries(SERVICE_ICON_MAP)) {
+    if (lower.includes(key)) return icon;
+  }
+  return "🔧";
+}
+
+const STATUS_MAP: Record<string, DummyOrder["status"]> = {
+  pending: "REQUESTED",
+  confirmed: "ACCEPTED",
+  completed: "COMPLETED",
+  cancelled: "CANCELLED",
+};
+
+function mapBookingToOrder(b: RealBooking): DummyOrder {
+  const serviceName = b.service?.name ?? "Service";
+  return {
+    id: `#${b.id.slice(-6).toUpperCase()}`,
+    serviceCategory: serviceName,
+    serviceIcon: getServiceIcon(serviceName),
+    providerName: b.provider?.business_name ?? b.customer?.full_name ?? "Provider",
+    date: new Date(b.scheduled_at).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }),
+    status: STATUS_MAP[b.status] ?? "REQUESTED",
+    totalPrice: b.total_price ?? 0,
+  };
+}
 
 const SERVICE_GROUPS: ServiceGroup[] = [
   {
@@ -361,6 +389,7 @@ function generateResponse(
   intent: Intent,
   input: string,
   user: User | Provider | null,
+  realBookings?: RealBooking[] | null,
 ): Omit<BotMessage, "id" | "timestamp" | "sender"> {
   const role = user?.role?.toLowerCase() ?? null;
   const name = user?.name?.split(" ")[0] || "there";
@@ -395,6 +424,28 @@ function generateResponse(
         };
       }
       if (role === "provider") {
+        // Provider: show their scheduled jobs if available
+        if (realBookings && realBookings.length > 0) {
+          return {
+            contentType: "order-cards",
+            text: `You have ${realBookings.length} booking${realBookings.length !== 1 ? "s" : ""} scheduled:`,
+            orders: realBookings.map(mapBookingToOrder),
+            quickReplies: [
+              { label: "💰 Earnings Info", value: "earnings" },
+              { label: "❓ More Help", value: "help" },
+            ],
+          };
+        }
+        if (realBookings && realBookings.length === 0) {
+          return {
+            contentType: "quick-replies",
+            text: "You have no bookings yet. When customers book your services, they'll appear here.",
+            quickReplies: [
+              { label: "💰 Earnings Info", value: "earnings" },
+              { label: "🛠️ Services Offered", value: "show services" },
+            ],
+          };
+        }
         return {
           contentType: "faq-answer",
           text: "As a provider, you manage bookings from your dashboard:",
@@ -406,13 +457,35 @@ function generateResponse(
           quickReplies: [{ label: "💰 Earnings Info", value: "earnings" }],
         };
       }
+      // Customer: show real bookings if fetched
+      if (realBookings && realBookings.length === 0) {
+        return {
+          contentType: "quick-replies",
+          text: "You don't have any bookings yet. Browse our services to get started!",
+          quickReplies: [
+            { label: "🛠️ Browse Services", value: "show services" },
+            { label: "❓ How to Book", value: "how to book" },
+          ],
+        };
+      }
+      if (realBookings && realBookings.length > 0) {
+        return {
+          contentType: "order-cards",
+          text: `Here are your ${realBookings.length} booking${realBookings.length !== 1 ? "s" : ""}:`,
+          orders: realBookings.map(mapBookingToOrder),
+          quickReplies: [
+            { label: "🛠️ Browse Services", value: "show services" },
+            { label: "❓ Cancel a Booking", value: "cancel booking" },
+          ],
+        };
+      }
+      // Fallback if fetch failed or not attempted
       return {
-        contentType: "order-cards",
-        text: "Here are your recent orders:",
-        orders: DUMMY_ORDERS,
+        contentType: "quick-replies",
+        text: "Unable to load your bookings right now. Please try again.",
         quickReplies: [
+          { label: "🔄 Try Again", value: "my orders" },
           { label: "🛠️ Browse Services", value: "show services" },
-          { label: "❓ Cancel a Booking", value: "cancel booking" },
         ],
       };
 
@@ -456,6 +529,27 @@ function generateResponse(
       };
 
     case "provider_bookings":
+      if (realBookings && realBookings.length > 0) {
+        return {
+          contentType: "order-cards",
+          text: `You have ${realBookings.length} booking${realBookings.length !== 1 ? "s" : ""} from customers:`,
+          orders: realBookings.map(mapBookingToOrder),
+          quickReplies: [
+            { label: "💰 Earnings Info", value: "earnings" },
+            { label: "❓ More Help", value: "help" },
+          ],
+        };
+      }
+      if (realBookings && realBookings.length === 0) {
+        return {
+          contentType: "quick-replies",
+          text: "No incoming bookings yet. Once customers book your services, they'll appear here.",
+          quickReplies: [
+            { label: "💰 Earnings Info", value: "earnings" },
+            { label: "🛠️ Services Offered", value: "show services" },
+          ],
+        };
+      }
       return {
         contentType: "faq-answer",
         text: "Managing your bookings:",
@@ -541,6 +635,7 @@ const STATUS_STYLES: Record<DummyOrder["status"], string> = {
   REQUESTED: "bg-amber-50 text-amber-700 border border-amber-200",
   ACCEPTED: "bg-teal-50 text-teal-700 border border-teal-200",
   COMPLETED: "bg-emerald-50 text-emerald-700 border border-emerald-200",
+  CANCELLED: "bg-slate-50 text-slate-500 border border-slate-200",
 };
 
 function OrderCard({ order }: { order: DummyOrder }) {
@@ -735,7 +830,7 @@ export const Chatbot: React.FC<ChatbotProps> = ({ user }) => {
     return () => window.removeEventListener("keydown", handler);
   }, [isOpen, handleClose]);
 
-  const handleSendMessage = (text: string) => {
+  const handleSendMessage = async (text: string) => {
     if (!text.trim() || isTyping) return;
 
     const userMsg: UserMessage = {
@@ -749,19 +844,35 @@ export const Chatbot: React.FC<ChatbotProps> = ({ user }) => {
     setInputValue("");
     setIsTyping(true);
 
-    setTimeout(() => {
-      const role = user?.role?.toLowerCase() ?? null;
-      const intent = detectIntent(text, role);
-      const payload = generateResponse(intent, text, user);
-      const botMsg: BotMessage = {
-        id: generateId(),
-        sender: "bot",
-        timestamp: new Date(),
-        ...payload,
-      };
-      setMessages((prev) => [...prev.slice(-49), botMsg]);
-      setIsTyping(false);
-    }, 750);
+    const role = user?.role?.toLowerCase() ?? null;
+    const intent = detectIntent(text, role);
+
+    // Fetch real booking data for order/booking intents
+    let realBookings: RealBooking[] | null = null;
+    if (user && (intent === "my_orders" || intent === "provider_bookings")) {
+      try {
+        const result = await fetchApi<ChatbotContext>("/chatbot/context");
+        if (result.success && result.data) {
+          const ctx = result.data as unknown as ChatbotContext;
+          realBookings = ctx.bookings ?? [];
+        }
+      } catch {
+        // realBookings stays null → fallback message shown
+      }
+    }
+
+    // Small delay for a natural conversational feel
+    await new Promise<void>((resolve) => setTimeout(resolve, 600));
+
+    const payload = generateResponse(intent, text, user, realBookings);
+    const botMsg: BotMessage = {
+      id: generateId(),
+      sender: "bot",
+      timestamp: new Date(),
+      ...payload,
+    };
+    setMessages((prev) => [...prev.slice(-49), botMsg]);
+    setIsTyping(false);
   };
 
   const roleBadge = user


### PR DESCRIPTION
## Summary
- New `GET /api/chatbot/context` endpoint returns the logged-in user's last 10 bookings, role-aware (customer vs provider)
- Chatbot frontend replaced hardcoded dummy orders with real API data
- Graceful fallback: shows empty state if user has no bookings, or prompts login if unauthenticated

## Changes
- `backend/src/controllers/chatbotController.js` _(new)_ — role-aware booking fetch with Supabase joins
- `backend/src/routes/chatbotRoutes.js` _(new)_ — registers `/context` route with `authenticate` middleware
- `backend/src/server.js` — mount `chatbotRoutes` at `/api/chatbot`
- `frontend/src/components/Chatbot.tsx` — async message handler, real booking cards, status mapping, cancellation status

## Dependencies
- Requires the booking feature to have real DB rows to display. Add 2-3 test booking rows in Supabase dashboard for the test user to see data in the chatbot.
- Booking UI (another team member) is NOT required — the chatbot already handles the unauthenticated + empty-bookings states gracefully.

## Test plan
- [ ] `GET /api/chatbot/context` with valid JWT returns `{ success: true, data: { role, bookings: [...] } }`
- [ ] `GET /api/chatbot/context` without JWT returns 401
- [ ] Customer chatbot: typing "my orders" or "show bookings" displays real booking cards
- [ ] Provider chatbot: typing "my jobs" or "incoming requests" displays real incoming bookings
- [ ] With no bookings in DB → empty state message shown
- [ ] Without login → "please log in" message shown