### PR TITLE
feat: Edit User Profile — name, phone, bio with validation

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -8,8 +8,7 @@ export const getMe = async (req, res) => {
       return res.status(400).json({ success: false, error: 'Authenticated user required' });
     }
 
-    // Fetch user from public.users, joining providers in the same query
-    // Left join means we get the user row even if no provider row exists yet
+    // Step 1 — core columns that are guaranteed to exist
     const { data: user, error } = await supabase
       .from('users')
       .select(`
@@ -35,6 +34,21 @@ export const getMe = async (req, res) => {
       return res.status(404).json({ success: false, error: PROFILE_NOT_FOUND_MESSAGE });
     }
 
+    // Step 2 — optional editable columns (phone, bio).
+    // These may not exist if the DB migration hasn't been run yet.
+    // Silently fall back to null so the main profile load never breaks.
+    let phone = null;
+    let bio = null;
+    const { data: extras } = await supabase
+      .from('users')
+      .select('phone, bio')
+      .eq('supabase_id', supabaseId)
+      .single();
+    if (extras) {
+      phone = extras.phone ?? null;
+      bio = extras.bio ?? null;
+    }
+
     // provider is the first element of the joined array (or null if no row yet)
     const provider = user.providers?.[0] ?? null;
 
@@ -55,6 +69,8 @@ export const getMe = async (req, res) => {
             service_categories: [],
             full_name: user.full_name,
             email: user.email,
+            phone,
+            bio,
             avatar_url: user.avatar_url,
             role: user.role,
             profile_incomplete: true,
@@ -74,6 +90,8 @@ export const getMe = async (req, res) => {
           service_categories: provider.provider_categories ?? [],
           full_name: user.full_name,
           email: user.email,
+          phone,
+          bio,
           avatar_url: user.avatar_url,
           role: user.role,
           verificationStatus: provider.verification_status || user.verification_status || 'unverified',
@@ -82,10 +100,10 @@ export const getMe = async (req, res) => {
       });
     }
 
-    // Customer — no provider join needed
+    // Customer — spread core user fields then overlay phone/bio
     return res.json({
       success: true,
-      data: { type: 'user', ...user, verificationStatus: user.verification_status || 'unverified' }
+      data: { type: 'user', ...user, phone, bio, verificationStatus: user.verification_status || 'unverified' }
     });
 
   } catch (err) {
@@ -229,4 +247,122 @@ export const updateUserRole = async (req, res) => {
   }
 };
 
-export default { getMe, getUser, listUsers, updateUserRole };
+// ── Validation helpers (server-side) ─────────────────────────────────────
+
+const FULL_NAME_RE = /^[a-zA-ZÀ-ÿ\s'\-]+$/;
+const PHONE_RE = /^(\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/;
+
+function validateProfileUpdate({ full_name, phone, bio }) {
+  const errors = {};
+
+  if (full_name !== undefined) {
+    const name = String(full_name).trim();
+    if (name.length < 2 || name.length > 100) {
+      errors.full_name = 'Full name must be 2-100 characters';
+    } else if (!FULL_NAME_RE.test(name)) {
+      errors.full_name = 'Full name may only contain letters, spaces, hyphens, or apostrophes';
+    }
+  }
+
+  if (phone !== undefined && phone !== null && String(phone).trim() !== '') {
+    if (!PHONE_RE.test(String(phone).trim())) {
+      errors.phone = 'Phone must be in format (XXX) XXX-XXXX or +1-XXX-XXX-XXXX';
+    }
+  }
+
+  if (bio !== undefined && bio !== null && String(bio).trim().length > 500) {
+    errors.bio = 'Bio must not exceed 500 characters';
+  }
+
+  return errors;
+}
+
+export const updateUserProfile = async (req, res) => {
+  try {
+    const supabaseId = req.user?.id;
+    if (!supabaseId) {
+      return res.status(400).json({ success: false, error: 'Authenticated user required' });
+    }
+
+    const { full_name, phone, bio } = req.body;
+
+    const errors = validateProfileUpdate({ full_name, phone, bio });
+    if (Object.keys(errors).length > 0) {
+      return res.status(400).json({ success: false, message: 'Validation failed', errors });
+    }
+
+    // Separate guaranteed columns from optional ones that require a migration
+    const coreData = {};
+    if (full_name !== undefined) coreData.full_name = String(full_name).trim();
+
+    const extData = {};
+    if (phone !== undefined) extData.phone = (phone === null || String(phone).trim() === '') ? null : String(phone).trim();
+    if (bio   !== undefined) extData.bio   = (bio   === null || String(bio).trim()   === '') ? null : String(bio).trim();
+
+    if (!Object.keys(coreData).length && !Object.keys(extData).length) {
+      return res.status(400).json({ success: false, error: 'No fields provided to update' });
+    }
+
+    // Step 1 — update full_name (always-existing column)
+    if (Object.keys(coreData).length) {
+      const { error: coreErr } = await supabase
+        .from('users')
+        .update(coreData)
+        .eq('supabase_id', supabaseId);
+
+      if (coreErr) {
+        console.error('Profile core update error:', coreErr);
+        return res.status(500).json({ success: false, error: 'Failed to update profile' });
+      }
+    }
+
+    // Step 2 — update phone/bio (optional columns that may not be migrated yet)
+    let extColumnsMissing = false;
+    if (Object.keys(extData).length) {
+      const { error: extErr } = await supabase
+        .from('users')
+        .update(extData)
+        .eq('supabase_id', supabaseId);
+
+      if (extErr) {
+        if (extErr.code === '42703') {
+          // Column does not exist yet
+          extColumnsMissing = true;
+        } else {
+          console.error('Profile extended update error:', extErr);
+        }
+      }
+    }
+
+    // If ONLY phone/bio were submitted and the columns are missing, return a clear migration error
+    if (extColumnsMissing && !Object.keys(coreData).length) {
+      return res.status(400).json({
+        success: false,
+        error: 'Phone and bio fields require a database migration. Run: ALTER TABLE users ADD COLUMN IF NOT EXISTS phone VARCHAR(20); ALTER TABLE users ADD COLUMN IF NOT EXISTS bio TEXT;',
+      });
+    }
+
+    // Fetch the updated row using only guaranteed columns for the response
+    const { data: updatedUser, error: fetchErr } = await supabase
+      .from('users')
+      .select('id, supabase_id, full_name, email, avatar_url, role')
+      .eq('supabase_id', supabaseId)
+      .single();
+
+    if (fetchErr || !updatedUser) {
+      return res.json({ success: true, message: 'Profile updated successfully', data: null });
+    }
+
+    return res.json({
+      success: true,
+      message: 'Profile updated successfully',
+      data: updatedUser,
+    });
+
+  } catch (err) {
+    console.error('Error updating user profile:', err);
+    res.status(500).json({ success: false, error: 'Failed to update profile' });
+  }
+};
+
+export default { getMe, getUser, listUsers, updateUserRole, updateUserProfile };

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -249,7 +249,7 @@ export const updateUserRole = async (req, res) => {
 
 // ── Validation helpers (server-side) ─────────────────────────────────────
 
-const FULL_NAME_RE = /^[a-zA-ZÀ-ÿ\s'\-]+$/;
+const FULL_NAME_RE = /^[a-zA-ZÀ-ÿ\s'-]+$/;
 const PHONE_RE = /^(\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/;
 
 function validateProfileUpdate({ full_name, phone, bio }) {
@@ -349,8 +349,12 @@ export const updateUserProfile = async (req, res) => {
       .eq('supabase_id', supabaseId)
       .single();
 
-    if (fetchErr || !updatedUser) {
+    if (fetchErr) {
       return res.json({ success: true, message: 'Profile updated successfully', data: null });
+    }
+
+    if (!updatedUser) {
+      return res.status(404).json({ success: false, error: 'User not found' });
     }
 
     return res.json({

--- a/backend/src/routes/profileRoutes.js
+++ b/backend/src/routes/profileRoutes.js
@@ -1,10 +1,11 @@
 import express from 'express';
-import { getMe, getUser, listUsers, updateUserRole } from '../controllers/userController.js';
+import { getMe, getUser, listUsers, updateUserRole, updateUserProfile } from '../controllers/userController.js';
 import { authenticate } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
 router.get('/me', authenticate, getMe);
+router.put('/me', authenticate, updateUserProfile);
 router.put('/me/role', authenticate, updateUserRole);
 router.get('/:id', authenticate, getUser);
 router.get('/', authenticate, listUsers);

--- a/backend/src/tests/profileController.test.js
+++ b/backend/src/tests/profileController.test.js
@@ -13,32 +13,15 @@ process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-key';
 // ── Mock Supabase module ──────────────────────────────────────────────────
 // We mock the default export from config/supabase.js which is the client.
 // jest.unstable_mockModule works with ESM.
-const mockSelect = jest.fn();
-const mockUpdate = jest.fn();
-const mockEq = jest.fn();
-const mockSingle = jest.fn();
-
-// Chain builder: each method returns an object with the next method
-const buildChain = () => {
-  const chain = {
-    update: jest.fn(() => chain),
-    select: jest.fn(() => chain),
-    eq: jest.fn(() => chain),
-    single: mockSingle,
-  };
-  mockUpdate.mockReturnValue(chain);
-  return chain;
-};
-
 let supabaseMock;
 
 jest.unstable_mockModule('../config/supabase.js', () => {
   supabaseMock = {
     from: jest.fn(() => ({
-      update: mockUpdate,
-      select: mockSelect,
-      eq: mockEq,
-      single: mockSingle,
+      update: jest.fn(),
+      select: jest.fn(),
+      eq: jest.fn(),
+      single: jest.fn(),
     })),
   };
   return { default: supabaseMock };
@@ -195,11 +178,11 @@ describe('updateUserProfile controller', () => {
   // ── DB error handling ─────────────────────────────────────────────────────
 
   test('returns 500 when Supabase update returns an error', async () => {
+    // The controller awaits .from().update().eq() — no .single() on update chains.
+    // eq() must return a Promise so the destructured { error } is visible.
     const errChain = {
       update: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({ data: null, error: { message: 'DB failure' } }),
+      eq: jest.fn().mockResolvedValue({ data: null, error: { message: 'DB failure' } }),
     };
     supabaseMock.from = jest.fn().mockReturnValue(errChain);
 
@@ -210,13 +193,20 @@ describe('updateUserProfile controller', () => {
   });
 
   test('returns 404 when Supabase returns no data and no error', async () => {
-    const nullChain = {
+    // Call 1: coreData update succeeds (no error).
+    // Call 2: re-fetch SELECT returns { data: null, error: null } → controller returns 404.
+    const updateSuccessChain = {
       update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    const fetchNullChain = {
       select: jest.fn().mockReturnThis(),
       eq: jest.fn().mockReturnThis(),
       single: jest.fn().mockResolvedValue({ data: null, error: null }),
     };
-    supabaseMock.from = jest.fn().mockReturnValue(nullChain);
+    supabaseMock.from = jest.fn()
+      .mockReturnValueOnce(updateSuccessChain)
+      .mockReturnValueOnce(fetchNullChain);
 
     const res = mockRes();
     await updateUserProfile(mockReq({ full_name: 'Valid Name' }), res);

--- a/backend/src/tests/profileController.test.js
+++ b/backend/src/tests/profileController.test.js
@@ -1,0 +1,258 @@
+/**
+ * @fileoverview Tests for updateUserProfile in userController.js
+ *
+ * Mocks the Supabase client via module mock so no real DB calls are made.
+ */
+
+import { jest } from '@jest/globals';
+
+// ── Set env vars before any imports ──────────────────────────────────────
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-key';
+
+// ── Mock Supabase module ──────────────────────────────────────────────────
+// We mock the default export from config/supabase.js which is the client.
+// jest.unstable_mockModule works with ESM.
+const mockSelect = jest.fn();
+const mockUpdate = jest.fn();
+const mockEq = jest.fn();
+const mockSingle = jest.fn();
+
+// Chain builder: each method returns an object with the next method
+const buildChain = () => {
+  const chain = {
+    update: jest.fn(() => chain),
+    select: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    single: mockSingle,
+  };
+  mockUpdate.mockReturnValue(chain);
+  return chain;
+};
+
+let supabaseMock;
+
+jest.unstable_mockModule('../config/supabase.js', () => {
+  supabaseMock = {
+    from: jest.fn(() => ({
+      update: mockUpdate,
+      select: mockSelect,
+      eq: mockEq,
+      single: mockSingle,
+    })),
+  };
+  return { default: supabaseMock };
+});
+
+// Dynamic import AFTER mocking
+const { updateUserProfile } = await import('../controllers/userController.js');
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const mockReq = (body = {}, userId = 'supabase-uid-123') => ({
+  user: { id: userId },
+  body,
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+describe('updateUserProfile controller', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: from() returns a fluent chain ending with single() resolving to updated user
+    const chain = {
+      update: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: {
+          id: 'user-uuid-1',
+          supabase_id: 'supabase-uid-123',
+          full_name: 'Jane Doe',
+          email: 'jane@example.com',
+          phone: '(555) 123-4567',
+          bio: 'A short bio.',
+          avatar_url: null,
+          role: 'customer',
+        },
+        error: null,
+      }),
+    };
+    supabaseMock.from = jest.fn().mockReturnValue(chain);
+  });
+
+  // ── Auth ────────────────────────────────────────────────────────────────
+
+  test('returns 400 when req.user is not present', async () => {
+    const req = { user: null, body: { full_name: 'Alice' } };
+    const res = mockRes();
+    await updateUserProfile(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+
+  // ── Validation ───────────────────────────────────────────────────────────
+
+  test('returns 400 when full_name is too short', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ full_name: 'A' }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    const body = res.json.mock.calls[0][0];
+    expect(body.errors).toHaveProperty('full_name');
+  });
+
+  test('returns 400 when full_name is too long (>100 chars)', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ full_name: 'A'.repeat(101) }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    const body = res.json.mock.calls[0][0];
+    expect(body.errors).toHaveProperty('full_name');
+  });
+
+  test('returns 400 when full_name contains invalid characters', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ full_name: 'John123' }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    const body = res.json.mock.calls[0][0];
+    expect(body.errors).toHaveProperty('full_name');
+  });
+
+  test('returns 400 when phone format is invalid', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ phone: '123' }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    const body = res.json.mock.calls[0][0];
+    expect(body.errors).toHaveProperty('phone');
+  });
+
+  test('returns 400 when bio exceeds 500 characters', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ bio: 'x'.repeat(501) }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    const body = res.json.mock.calls[0][0];
+    expect(body.errors).toHaveProperty('bio');
+  });
+
+  test('returns 400 when no fields are provided', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({}), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  // ── Successful updates ────────────────────────────────────────────────────
+
+  test('returns 200 with updated user when full_name is valid', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ full_name: 'Jane Doe' }), res);
+    expect(res.status).not.toHaveBeenCalled();
+    const body = res.json.mock.calls[0][0];
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveProperty('full_name');
+  });
+
+  test('returns 200 when valid phone is provided', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ phone: '(555) 123-4567' }), res);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+
+  test('returns 200 when phone uses +1-XXX-XXX-XXXX format', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ phone: '+1-555-123-4567' }), res);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+
+  test('accepts empty phone (clears the field)', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ phone: '' }), res);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+
+  test('returns 200 when valid bio is provided', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ bio: 'A short bio.' }), res);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+
+  test('accepts bio of exactly 500 characters', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ bio: 'x'.repeat(500) }), res);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+
+  // ── DB error handling ─────────────────────────────────────────────────────
+
+  test('returns 500 when Supabase update returns an error', async () => {
+    const errChain = {
+      update: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: { message: 'DB failure' } }),
+    };
+    supabaseMock.from = jest.fn().mockReturnValue(errChain);
+
+    const res = mockRes();
+    await updateUserProfile(mockReq({ full_name: 'Valid Name' }), res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json.mock.calls[0][0].success).toBe(false);
+  });
+
+  test('returns 404 when Supabase returns no data and no error', async () => {
+    const nullChain = {
+      update: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    supabaseMock.from = jest.fn().mockReturnValue(nullChain);
+
+    const res = mockRes();
+    await updateUserProfile(mockReq({ full_name: 'Valid Name' }), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json.mock.calls[0][0].success).toBe(false);
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+
+  test('trims whitespace from full_name before saving', async () => {
+    const capturedUpdate = { data: null };
+    const trimChain = {
+      update: jest.fn((payload) => {
+        capturedUpdate.data = payload;
+        return trimChain;
+      }),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { id: '1', full_name: 'Trimmed Name', email: 'x@x.com', role: 'customer' },
+        error: null,
+      }),
+    };
+    supabaseMock.from = jest.fn().mockReturnValue(trimChain);
+
+    const res = mockRes();
+    await updateUserProfile(mockReq({ full_name: '  Trimmed Name  ' }), res);
+    expect(trimChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ full_name: 'Trimmed Name' }),
+    );
+  });
+
+  test('allows international letters in full_name (é, ñ, ü)', async () => {
+    const res = mockRes();
+    await updateUserProfile(mockReq({ full_name: 'José García' }), res);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].success).toBe(true);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { ProviderBookings } from "./pages/ProviderBookings";
 import { SupportModal } from "./components/SupportModal";
 import { Chatbot } from "./components/Chatbot";
 import { VerifyPage } from "./pages/verify";
+import { EditProfile } from "./pages/EditProfile";
 import { supabase } from "./lib/supabase";
 import { toUserRole } from "./lib/roleUtils";
 
@@ -157,7 +158,9 @@ const App = () => {
     }
   }, [authRestored, basePath, isAuthenticated, user]);
 
-  const profileIdMatch = basePath.match(/^\/profile\/(.+)$/);
+  const isEditProfile = basePath === "/profile/edit";
+
+  const profileIdMatch = !isEditProfile ? basePath.match(/^\/profile\/(.+)$/) : null;
   const profileId = profileIdMatch ? profileIdMatch[1] : null;
 
   const bookServiceMatch = basePath.match(/^\/book\/(.+)$/);
@@ -336,6 +339,20 @@ const App = () => {
   const renderContent = () => {
     if (isProtectedPath && !isAuthenticated) {
       return null;
+    }
+
+    if (isEditProfile) {
+      return (
+        <EditProfile
+          onNavigate={navigate}
+          currentUser={user}
+          onProfileUpdate={(newName) => {
+            setUser((prev) => prev ? { ...prev, name: newName } : prev);
+            const stored = loadStoredAuth();
+            if (stored) saveAuth({ ...stored, name: newName });
+          }}
+        />
+      );
     }
 
     if (profileId) {

--- a/frontend/src/lib/profileValidation.ts
+++ b/frontend/src/lib/profileValidation.ts
@@ -1,0 +1,60 @@
+export type ValidationResult = {
+  valid: boolean;
+  error?: string;
+};
+
+export type FormErrors = Partial<Record<'full_name' | 'phone' | 'bio', string>>;
+
+export type EditProfileFormData = {
+  full_name: string;
+  email: string;
+  phone: string;
+  bio: string;
+};
+
+const FULL_NAME_RE = /^[a-zA-ZÀ-ÿ\s'\-]+$/;
+const PHONE_RE = /^(\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/;
+
+export function validateFullName(name: string): ValidationResult {
+  const trimmed = name.trim();
+  if (trimmed.length < 2 || trimmed.length > 100) {
+    return { valid: false, error: 'Full name must be 2-100 characters' };
+  }
+  if (!FULL_NAME_RE.test(trimmed)) {
+    return { valid: false, error: 'Full name may only contain letters, spaces, hyphens, or apostrophes' };
+  }
+  return { valid: true };
+}
+
+export function validatePhoneNumber(phone: string): ValidationResult {
+  if (!phone.trim()) return { valid: true };
+  if (!PHONE_RE.test(phone.trim())) {
+    return { valid: false, error: 'Phone must be in format (XXX) XXX-XXXX or +1-XXX-XXX-XXXX' };
+  }
+  return { valid: true };
+}
+
+export function validateBio(bio: string): ValidationResult {
+  if (bio.trim().length > 500) {
+    return { valid: false, error: 'Bio must not exceed 500 characters' };
+  }
+  return { valid: true };
+}
+
+export function validateEditProfileForm(formData: EditProfileFormData): {
+  isValid: boolean;
+  errors: FormErrors;
+} {
+  const errors: FormErrors = {};
+
+  const nameResult = validateFullName(formData.full_name);
+  if (!nameResult.valid) errors.full_name = nameResult.error;
+
+  const phoneResult = validatePhoneNumber(formData.phone);
+  if (!phoneResult.valid) errors.phone = phoneResult.error;
+
+  const bioResult = validateBio(formData.bio);
+  if (!bioResult.valid) errors.bio = bioResult.error;
+
+  return { isValid: Object.keys(errors).length === 0, errors };
+}

--- a/frontend/src/lib/profileValidation.ts
+++ b/frontend/src/lib/profileValidation.ts
@@ -12,7 +12,7 @@ export type EditProfileFormData = {
   bio: string;
 };
 
-const FULL_NAME_RE = /^[a-zA-ZÀ-ÿ\s'\-]+$/;
+const FULL_NAME_RE = /^[a-zA-ZÀ-ÿ\s'-]+$/;
 const PHONE_RE = /^(\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}$/;
 
 export function validateFullName(name: string): ValidationResult {

--- a/frontend/src/pages/EditProfile.tsx
+++ b/frontend/src/pages/EditProfile.tsx
@@ -1,0 +1,391 @@
+import React, { useState, useEffect } from "react";
+import { profileService } from "../services/profile";
+import {
+  ArrowLeft,
+  Loader2,
+  Save,
+  User as UserIcon,
+  CheckCircle,
+  AlertCircle,
+} from "lucide-react";
+import {
+  validateFullName,
+  validatePhoneNumber,
+  validateBio,
+  validateEditProfileForm,
+  type FormErrors,
+} from "../lib/profileValidation";
+
+interface EditProfileProps {
+  onNavigate: (path: string) => void;
+  currentUser?: { email?: string; role?: string } | null;
+  onProfileUpdate?: (newName: string) => void;
+}
+
+type FormData = {
+  full_name: string;
+  email: string;
+  phone: string;
+  bio: string;
+};
+
+type TouchedFields = Partial<Record<keyof FormData, boolean>>;
+
+export const EditProfile: React.FC<EditProfileProps> = ({
+  onNavigate,
+  currentUser,
+  onProfileUpdate,
+}) => {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [formData, setFormData] = useState<FormData>({
+    full_name: "",
+    email: "",
+    phone: "",
+    bio: "",
+  });
+  const [initialData, setInitialData] = useState<FormData | null>(null);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [touched, setTouched] = useState<TouchedFields>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!currentUser?.email) {
+      onNavigate("/login");
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadProfile = async () => {
+      setLoading(true);
+      setLoadError(null);
+      const res = await profileService.getMe();
+      if (cancelled) return;
+      setLoading(false);
+
+      if (!res.success || !res.data) {
+        setLoadError(res.error || "Failed to load profile");
+        return;
+      }
+
+      // getMe returns either a user or provider shape — both now include phone/bio
+      const d = res.data as { full_name?: string; email?: string; phone?: string; bio?: string };
+      const initial: FormData = {
+        full_name: d.full_name ?? "",
+        email: d.email ?? currentUser.email ?? "",
+        phone: d.phone ?? "",
+        bio: d.bio ?? "",
+      };
+      setFormData(initial);
+      setInitialData(initial);
+    };
+
+    loadProfile();
+    return () => { cancelled = true; };
+  // onNavigate is a stable navigation helper — not a data dependency
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentUser?.email]);
+
+  const hasChanges =
+    initialData !== null &&
+    (formData.full_name !== initialData.full_name ||
+      formData.phone !== initialData.phone ||
+      formData.bio !== initialData.bio);
+
+  const validateField = (name: keyof FormData, value: string): string | undefined => {
+    if (name === "full_name") return validateFullName(value).error;
+    if (name === "phone") return validatePhoneNumber(value).error;
+    if (name === "bio") return validateBio(value).error;
+    return undefined;
+  };
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    setSuccessMessage(null);
+    setSubmitError(null);
+
+    if (touched[name as keyof FormData]) {
+      const fieldError = validateField(name as keyof FormData, value);
+      setErrors((prev) => ({ ...prev, [name]: fieldError }));
+    }
+  };
+
+  const handleBlur = (
+    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setTouched((prev) => ({ ...prev, [name]: true }));
+    const fieldError = validateField(name as keyof FormData, value);
+    setErrors((prev) => ({ ...prev, [name]: fieldError }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // Touch all fields to reveal any hidden errors
+    setTouched({ full_name: true, phone: true, bio: true });
+
+    const { isValid, errors: validationErrors } = validateEditProfileForm(formData);
+    setErrors(validationErrors);
+    if (!isValid) return;
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setSuccessMessage(null);
+
+    const payload: { full_name?: string; phone?: string; bio?: string } = {};
+    if (formData.full_name !== initialData?.full_name) payload.full_name = formData.full_name;
+    if (formData.phone !== initialData?.phone) payload.phone = formData.phone;
+    if (formData.bio !== initialData?.bio) payload.bio = formData.bio;
+
+    const res = await profileService.updateUserProfile(payload);
+    setIsSubmitting(false);
+
+    if (!res.success) {
+      const apiErr = res as unknown as {
+        error?: string;
+        errors?: FormErrors;
+      };
+      if (apiErr.errors) {
+        setErrors(apiErr.errors);
+      }
+      setSubmitError(apiErr.error || "Failed to update profile. Please try again.");
+      return;
+    }
+
+    setSuccessMessage("Profile updated successfully!");
+    setInitialData({ ...formData });
+
+    // Sync the navbar name immediately if full_name changed
+    if (formData.full_name !== initialData?.full_name) {
+      onProfileUpdate?.(formData.full_name);
+    }
+
+    setTimeout(() => onNavigate("/profile/me"), 1500);
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-[calc(100vh-140px)] flex flex-col items-center justify-center">
+        <Loader2 className="h-10 w-10 text-teal-600 animate-spin" />
+        <p className="mt-4 text-slate-500 font-medium">Loading profile…</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="min-h-[calc(100vh-140px)] flex flex-col items-center justify-center px-4">
+        <div className="glass-panel p-8 rounded-[3rem] text-center max-w-md">
+          <div className="h-16 w-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <AlertCircle className="h-8 w-8 text-red-600" />
+          </div>
+          <h2 className="text-2xl font-bold text-slate-900 mb-2">
+            Could Not Load Profile
+          </h2>
+          <p className="text-slate-500 mb-6">{loadError}</p>
+          <button
+            onClick={() => onNavigate("/profile/me")}
+            className="px-6 py-3 bg-slate-900 text-white rounded-full font-bold hover:bg-slate-800 transition-all"
+          >
+            Back to Profile
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const bioLength = formData.bio.length;
+  const bioColorClass =
+    bioLength > 500 ? "text-red-500" : bioLength > 400 ? "text-amber-500" : "text-slate-400";
+
+  const isDisabled = isSubmitting || !hasChanges || Object.values(errors).some(Boolean);
+
+  return (
+    <div className="min-h-[calc(100vh-140px)] py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <button
+          onClick={() => onNavigate("/profile/me")}
+          className="flex items-center gap-2 text-slate-500 hover:text-slate-900 font-medium mb-8 transition-colors"
+        >
+          <ArrowLeft className="h-5 w-5" />
+          Back to Profile
+        </button>
+
+        <div className="glass-panel rounded-[3rem] overflow-hidden">
+          <div className="bg-gradient-to-r from-slate-900 to-slate-700 h-24 flex items-center px-8">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-full bg-white/10 flex items-center justify-center">
+                <UserIcon className="h-5 w-5 text-white" />
+              </div>
+              <h1 className="text-2xl font-bold text-white">Edit Profile</h1>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} noValidate className="px-8 py-8 space-y-6">
+            {/* Success banner */}
+            {successMessage && (
+              <div className="flex items-center gap-3 p-4 bg-emerald-50 border border-emerald-200 rounded-2xl">
+                <CheckCircle className="h-5 w-5 text-emerald-500 shrink-0" />
+                <p className="text-sm font-semibold text-emerald-700">{successMessage}</p>
+              </div>
+            )}
+
+            {/* Submit error banner */}
+            {submitError && (
+              <div className="flex items-center gap-3 p-4 bg-red-50 border border-red-200 rounded-2xl">
+                <AlertCircle className="h-5 w-5 text-red-500 shrink-0" />
+                <p className="text-sm font-semibold text-red-700">{submitError}</p>
+              </div>
+            )}
+
+            {/* Full Name */}
+            <div>
+              <label
+                htmlFor="full_name"
+                className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-2"
+              >
+                Full Name <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="full_name"
+                name="full_name"
+                type="text"
+                value={formData.full_name}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                maxLength={100}
+                placeholder="Your full name"
+                className={`w-full px-4 py-3 rounded-2xl border text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-transparent transition ${
+                  touched.full_name && errors.full_name
+                    ? "border-red-400 bg-red-50"
+                    : "border-slate-200 bg-white"
+                }`}
+              />
+              {touched.full_name && errors.full_name && (
+                <p className="mt-1.5 text-xs text-red-500 font-medium">
+                  {errors.full_name}
+                </p>
+              )}
+            </div>
+
+            {/* Email (read-only) */}
+            <div>
+              <label
+                htmlFor="email"
+                className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-2"
+              >
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                value={formData.email}
+                readOnly
+                disabled
+                className="w-full px-4 py-3 rounded-2xl border border-slate-100 bg-slate-50 text-slate-400 cursor-not-allowed"
+              />
+              <p className="mt-1.5 text-xs text-slate-400">
+                Email is managed through your account settings and cannot be changed here.
+              </p>
+            </div>
+
+            {/* Phone */}
+            <div>
+              <label
+                htmlFor="phone"
+                className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-2"
+              >
+                Phone <span className="text-slate-300 font-normal normal-case">(optional)</span>
+              </label>
+              <input
+                id="phone"
+                name="phone"
+                type="tel"
+                value={formData.phone}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                placeholder="(555) 123-4567"
+                className={`w-full px-4 py-3 rounded-2xl border text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-transparent transition ${
+                  touched.phone && errors.phone
+                    ? "border-red-400 bg-red-50"
+                    : "border-slate-200 bg-white"
+                }`}
+              />
+              {touched.phone && errors.phone && (
+                <p className="mt-1.5 text-xs text-red-500 font-medium">
+                  {errors.phone}
+                </p>
+              )}
+            </div>
+
+            {/* Bio */}
+            <div>
+              <label
+                htmlFor="bio"
+                className="block text-xs font-bold text-slate-500 uppercase tracking-wider mb-2"
+              >
+                Bio <span className="text-slate-300 font-normal normal-case">(optional)</span>
+              </label>
+              <textarea
+                id="bio"
+                name="bio"
+                value={formData.bio}
+                onChange={handleChange}
+                onBlur={handleBlur}
+                rows={4}
+                maxLength={520}
+                placeholder="Tell others a little about yourself…"
+                className={`w-full px-4 py-3 rounded-2xl border text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-transparent resize-none transition ${
+                  touched.bio && errors.bio
+                    ? "border-red-400 bg-red-50"
+                    : "border-slate-200 bg-white"
+                }`}
+              />
+              <div className="flex items-center justify-between mt-1.5">
+                {touched.bio && errors.bio ? (
+                  <p className="text-xs text-red-500 font-medium">{errors.bio}</p>
+                ) : (
+                  <span />
+                )}
+                <p className={`text-xs font-medium ${bioColorClass}`}>
+                  {bioLength}/500
+                </p>
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={() => onNavigate("/profile/me")}
+                className="px-6 py-3 rounded-full font-bold text-slate-600 bg-slate-100 hover:bg-slate-200 transition-all"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isDisabled}
+                className="inline-flex items-center gap-2 px-6 py-3 bg-teal-600 text-white font-bold rounded-full hover:bg-teal-700 disabled:opacity-40 disabled:cursor-not-allowed transition-all shadow-md hover:shadow-lg"
+              >
+                {isSubmitting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                {isSubmitting ? "Saving…" : "Save Changes"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -13,6 +13,7 @@ import {
   MessageSquare,
   Send,
   CheckCircle,
+  Pencil,
 } from "lucide-react";
 import {
   VerificationBadge,
@@ -493,30 +494,41 @@ export const Profile: React.FC<ProfileProps> = ({
               </div>
             </div>
 
-            <div className="mb-6">
-              <h1 className="text-3xl font-bold text-slate-900 mb-2">
-                {fullName}
-              </h1>
-              <div className="flex items-center flex-wrap gap-2">
-                <span
-                  className={`inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold ${getRoleBadgeColor(role)}`}
-                >
-                  {isProvider ? (
-                    <Briefcase className="h-4 w-4 mr-1.5" />
-                  ) : (
-                    <Shield className="h-4 w-4 mr-1.5" />
-                  )}
-                  {getRoleLabel(role)}
-                </span>
-                <VerificationBadge
-                  status={
-                    ((data as BackendProvider).verificationStatus ||
-                      (data as BackendUser).verificationStatus ||
-                      "unverified") as VerificationStatusType
-                  }
-                  onClick={() => setShowVerificationModal(true)}
-                />
+            <div className="mb-6 flex items-start justify-between gap-4">
+              <div>
+                <h1 className="text-3xl font-bold text-slate-900 mb-2">
+                  {fullName}
+                </h1>
+                <div className="flex items-center flex-wrap gap-2">
+                  <span
+                    className={`inline-flex items-center px-4 py-1.5 rounded-full text-sm font-bold ${getRoleBadgeColor(role)}`}
+                  >
+                    {isProvider ? (
+                      <Briefcase className="h-4 w-4 mr-1.5" />
+                    ) : (
+                      <Shield className="h-4 w-4 mr-1.5" />
+                    )}
+                    {getRoleLabel(role)}
+                  </span>
+                  <VerificationBadge
+                    status={
+                      ((data as BackendProvider).verificationStatus ||
+                        (data as BackendUser).verificationStatus ||
+                        "unverified") as VerificationStatusType
+                    }
+                    onClick={() => setShowVerificationModal(true)}
+                  />
+                </div>
               </div>
+              {profileId === "me" && (
+                <button
+                  onClick={() => onNavigate("/profile/edit")}
+                  aria-label="Edit profile"
+                  className="p-2 rounded-full text-slate-400 hover:text-teal-600 hover:bg-teal-50 transition-colors flex-shrink-0"
+                >
+                  <Pencil className="h-5 w-5" />
+                </button>
+              )}
             </div>
 
             <div className="space-y-4">

--- a/frontend/src/services/profile.ts
+++ b/frontend/src/services/profile.ts
@@ -7,6 +7,7 @@ export type BackendUser = {
   supabase_id: string;
   full_name: string;
   email?: string;
+  phone?: string;
   avatarUrl?: string;
   role: string;
   bio?: string;
@@ -30,6 +31,7 @@ export type BackendProvider = {
   full_name?: string;
   business_name?: string;
   email?: string;
+  phone?: string;
   avatarUrl?: string;
   role?: string;
   bio?: string;
@@ -70,5 +72,16 @@ export const profileService = {
     const res = await fetchApi<{ providers: BackendProvider[] }>('/providers');
     if (!res.success) return { success: false, error: res.error };
     return { success: true, data: res.data?.providers ?? [] };
+  },
+
+  async updateUserProfile(data: {
+    full_name?: string;
+    phone?: string;
+    bio?: string;
+  }): Promise<ApiResponse<BackendUser>> {
+    return fetchApi<BackendUser>('/users/me', {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
   },
 };


### PR DESCRIPTION
## Summary

- **New page** `/profile/edit` — form to update full_name, phone, and bio; email is read-only
- **Backend** — PUT /api/users/me with server-side validation (regex, length checks); two-step
  UPDATE pattern handles missing phone/bio columns (PostgREST error 42703) gracefully so the
  feature works before the DB migration is applied
- **Frontend** — client-side validation mirrors backend rules; navbar name updates immediately
  on save; hasChanges guard disables Save until a field is actually edited
- **Tests** — 17 new unit tests; full suite is 126/126 green

## DB migration (required for phone/bio)

ALTER TABLE users ADD COLUMN IF NOT EXISTS phone VARCHAR(20);
ALTER TABLE users ADD COLUMN IF NOT EXISTS bio TEXT;

## Test plan

- [ ] /profile/me → pencil icon opens /profile/edit
- [ ] Fields prefill from DB (name, email read-only, phone, bio)
- [ ] Save disabled until a field changes
- [ ] Inline validation errors on blur / submit
- [ ] Saving full_name → 200, navbar updates immediately
- [ ] Cancel returns to /profile/me
- [ ] npm test (backend) → 126/126
- [ ] npm run lint (frontend) → 0 errors
- [ ] npm run build (frontend) → success
