### PR TITLE
feat(SER-125): 24hr booking reminder email

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,7 @@
         "morgan": "^1.10.1",
         "multer": "^2.1.1",
         "node-cron": "^4.2.1",
-        "resend": "^6.1.3",
+        "nodemailer": "^8.0.7",
         "uuid": "^14.0.0"
       },
       "devDependencies": {
@@ -5338,6 +5338,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
@@ -5883,23 +5892,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resend": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.1.3.tgz",
-      "integrity": "sha512-vHRdmU3q+nS5x7cYHZpAQ5zpZE+DV+7q6axIUiRcxYsoUpjBuW50zwdrOz+8O6vUbjGFIz4r2qkt4s+2G0y4GA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@react-email/render": "*"
-      },
-      "peerDependenciesMeta": {
-        "@react-email/render": {
-          "optional": true
-        }
       }
     },
     "node_modules/resolve": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,6 +22,7 @@
         "jsonwebtoken": "^9.0.3",
         "morgan": "^1.10.1",
         "multer": "^2.1.1",
+        "node-cron": "^4.2.1",
         "resend": "^6.1.3",
         "uuid": "^14.0.0"
       },
@@ -72,6 +73,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1598,6 +1600,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2029,6 +2032,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2787,6 +2791,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5268,6 +5273,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-domexception": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "seed:users": "node src/scripts/seedUsers.js",
     "seed:services": "node src/scripts/seedServices.js",
     "seed:providers": "node src/scripts/seedProviders.js",
+    "seed:reviews": "node src/scripts/seedReviews.js",
     "seed:all": "npm run seed:categories && npm run seed:users && npm run seed:providers",
     "lint": "eslint src"
   },
@@ -44,6 +45,7 @@
     "jsonwebtoken": "^9.0.3",
     "morgan": "^1.10.1",
     "multer": "^2.1.1",
+    "node-cron": "^4.2.1",
     "resend": "^6.1.3",
     "uuid": "^14.0.0"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,7 +46,7 @@
     "morgan": "^1.10.1",
     "multer": "^2.1.1",
     "node-cron": "^4.2.1",
-    "resend": "^6.1.3",
+    "nodemailer": "^8.0.7",
     "uuid": "^14.0.0"
   },
   "devDependencies": {

--- a/backend/src/routes/testRoutes.js
+++ b/backend/src/routes/testRoutes.js
@@ -1,9 +1,11 @@
 import express from 'express';
+import supabase from '../config/supabase.js';
+import { checkAndSendReminders } from '../services/reminderService.js';
+import { sendBookingReminderEmail } from '../services/emailService.js';
 
 const router = express.Router();
 
-// ── Dev/test helper routes ───────────────────────────────────────────────
-// GET /api/test/ping — confirms the test router is alive
+// GET /api/test/ping
 router.get('/ping', (req, res) => {
   res.json({
     success: true,
@@ -11,6 +13,76 @@ router.get('/ping', (req, res) => {
     timestamp: new Date().toISOString(),
     env: process.env.NODE_ENV || 'development',
   });
+});
+
+/**
+ * POST /api/test/trigger-reminders
+ * Manually runs the reminder check against the current 23.5–24.5 hr window.
+ * Use this to verify the cron logic without waiting for the scheduler.
+ *
+ * To create a booking in the right window first:
+ *   POST /api/bookings with scheduled_at = NOW + 24h
+ */
+router.post('/trigger-reminders', async (req, res) => {
+  try {
+    const result = await checkAndSendReminders();
+    res.json({ success: true, ...result });
+  } catch (err) {
+    console.error('trigger-reminders error:', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+/**
+ * POST /api/test/send-reminder/:bookingId
+ * Force-sends the reminder email for a specific booking, ignoring the time window.
+ * Useful for checking the email template with real DB data.
+ *
+ * Example:
+ *   curl -X POST http://localhost:3000/api/test/send-reminder/<bookingId>
+ */
+router.post('/send-reminder/:bookingId', async (req, res) => {
+  try {
+    const { data: booking, error } = await supabase
+      .from('bookings')
+      .select(`
+        id, scheduled_at,
+        address_street, address_city, address_state, address_zip,
+        customer:users!bookings_customer_id_fkey(email, full_name),
+        service:services(name),
+        provider:providers(business_name)
+      `)
+      .eq('id', req.params.bookingId)
+      .single();
+
+    if (error || !booking) {
+      return res.status(404).json({ success: false, error: 'Booking not found' });
+    }
+
+    const customerEmail = booking.customer?.email;
+    if (!customerEmail) {
+      return res.status(400).json({ success: false, error: 'No customer email on this booking' });
+    }
+
+    const addressParts = [
+      booking.address_street, booking.address_city,
+      booking.address_state,  booking.address_zip,
+    ].filter(Boolean);
+
+    const result = await sendBookingReminderEmail({
+      to:           customerEmail,
+      customerName: booking.customer?.full_name        || 'Customer',
+      serviceName:  booking.service?.name              || 'Service',
+      providerName: booking.provider?.business_name    || 'Provider',
+      scheduledAt:  booking.scheduled_at,
+      address:      addressParts.join(', '),
+    });
+
+    res.json({ success: result.success, emailId: result.id, error: result.error });
+  } catch (err) {
+    console.error('send-reminder error:', err);
+    res.status(500).json({ success: false, error: err.message });
+  }
 });
 
 export default router;

--- a/backend/src/routes/testRoutes.js
+++ b/backend/src/routes/testRoutes.js
@@ -59,7 +59,7 @@ router.post('/send-reminder/:bookingId', async (req, res) => {
       return res.status(404).json({ success: false, error: 'Booking not found' });
     }
 
-    const customerEmail = booking.customer?.email;
+    const customerEmail = req.query.to || booking.customer?.email;
     if (!customerEmail) {
       return res.status(400).json({ success: false, error: 'No customer email on this booking' });
     }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -7,6 +7,7 @@ import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
 import  { checkSupabaseConnection } from './config/supabase.js';
 import { validateVdaServiceConfig } from './config/vdaServiceConfig.js';
+import { startReminderCron } from './services/reminderService.js';
 import categoryRoutes from './routes/categoryRoutes.js';
 import serviceRoutes from './routes/serviceRoutes.js';
 import profileRoutes from './routes/profileRoutes.js';
@@ -29,6 +30,7 @@ const app = express();
 if (process.env.NODE_ENV !== 'test') {
   checkSupabaseConnection();
   validateVdaServiceConfig();
+  startReminderCron();
 }
 
 // Rate limiting

--- a/backend/src/services/emailService.js
+++ b/backend/src/services/emailService.js
@@ -1,92 +1,61 @@
-import { Resend } from 'resend';
+import nodemailer from 'nodemailer';
 import dotenv from 'dotenv';
 
 dotenv.config();
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: process.env.GMAIL_USER,
+    pass: process.env.GMAIL_APP_PASSWORD,
+  },
+});
 
-/**
- * Send email using Resend
- */
 export const sendEmail = async ({ to, subject, html, text }) => {
   try {
-    console.log('🔧 Attempting to send email via Resend...');
-    
-    // Resend returns { data, error }
-    const { data, error } = await resend.emails.send({
-      from: `${process.env.FROM_NAME} <${process.env.FROM_EMAIL}>`,
-      to: [to],
+    console.log('🔧 Attempting to send email via Gmail...');
+    const info = await transporter.sendMail({
+      from: `ServiceHub <${process.env.GMAIL_USER}>`,
+      to,
       subject,
       html,
-      text: text || undefined
+      text: text || undefined,
     });
-
-    // Check if there was an error
-    if (error) {
-      console.error('❌ Resend API error:', error);
-      return { success: false, error: error.message || error };
-    }
-
-    // Success!
-    console.log('✅ Email sent successfully via Resend');
-    console.log('   Email ID:', data?.id);
-    
-    return { 
-      success: true, 
-      id: data?.id,
-      data: data
-    };
+    console.log('✅ Email sent successfully via Gmail');
+    console.log('   Message ID:', info.messageId);
+    return { success: true, id: info.messageId };
   } catch (error) {
     console.error('❌ Email send error:', error);
     return { success: false, error: error.message };
   }
 };
 
-/**
- * Send welcome email
- */
 export const sendWelcomeEmail = async (userEmail, userName) => {
-  const html = `
-    <h1>Welcome to ServiceHub, ${userName}!</h1>
-    <p>Thank you for joining ServiceHub.</p>
-    <p>Best regards,<br>The ServiceHub Team</p>
-  `;
-
   return await sendEmail({
     to: userEmail,
     subject: 'Welcome to ServiceHub!',
-    html
+    html: `<h1>Welcome to ServiceHub, ${userName}!</h1><p>Thank you for joining ServiceHub.</p><p>Best regards,<br>The ServiceHub Team</p>`,
   });
 };
 
-/**
- * Send booking confirmation
- */
 export const sendBookingConfirmation = async (userEmail, bookingDetails) => {
   const { serviceName, providerName, scheduledAt, totalPrice } = bookingDetails;
-  
-  const html = `
-    <h1>Booking Confirmed!</h1>
-    <p>Your booking details:</p>
-    <ul>
-      <li><strong>Service:</strong> ${serviceName}</li>
-      <li><strong>Provider:</strong> ${providerName}</li>
-      <li><strong>Scheduled:</strong> ${new Date(scheduledAt).toLocaleString()}</li>
-      <li><strong>Total:</strong> $${totalPrice}</li>
-    </ul>
-    <p>Best regards,<br>The ServiceHub Team</p>
-  `;
-
   return await sendEmail({
     to: userEmail,
     subject: 'Booking Confirmation - ServiceHub',
-    html
+    html: `
+      <h1>Booking Confirmed!</h1>
+      <ul>
+        <li><strong>Service:</strong> ${serviceName}</li>
+        <li><strong>Provider:</strong> ${providerName}</li>
+        <li><strong>Scheduled:</strong> ${new Date(scheduledAt).toLocaleString()}</li>
+        <li><strong>Total:</strong> $${totalPrice}</li>
+      </ul>
+      <p>Best regards,<br>The ServiceHub Team</p>
+    `,
   });
 };
 
-/**
- * Send 24-hour booking reminder email (SER-125)
- */
 export const sendBookingReminderEmail = async ({
   to, customerName, serviceName, providerName, scheduledAt, address
 }) => {
@@ -130,7 +99,7 @@ export const sendBookingReminderEmail = async ({
     to,
     subject: `Reminder: ${serviceName} appointment tomorrow at ${timeStr}`,
     html,
-    text: `Hi ${customerName}, reminder: ${serviceName} with ${providerName} is tomorrow (${dateStr} at ${timeStr})${address ? ' at ' + address : ''}.`
+    text: `Hi ${customerName}, reminder: ${serviceName} with ${providerName} is tomorrow (${dateStr} at ${timeStr})${address ? ' at ' + address : ''}.`,
   });
 };
 

--- a/backend/src/services/emailService.js
+++ b/backend/src/services/emailService.js
@@ -84,4 +84,54 @@ export const sendBookingConfirmation = async (userEmail, bookingDetails) => {
   });
 };
 
-export default { sendEmail, sendWelcomeEmail, sendBookingConfirmation };
+/**
+ * Send 24-hour booking reminder email (SER-125)
+ */
+export const sendBookingReminderEmail = async ({
+  to, customerName, serviceName, providerName, scheduledAt, address
+}) => {
+  const dateStr = new Date(scheduledAt).toLocaleDateString('en-US', {
+    weekday: 'long', month: 'long', day: 'numeric', year: 'numeric'
+  });
+  const timeStr = new Date(scheduledAt).toLocaleTimeString('en-US', {
+    hour: '2-digit', minute: '2-digit'
+  });
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family:Arial,sans-serif;background:#f4f4f4;padding:20px;">
+      <div style="max-width:600px;margin:0 auto;background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.1);">
+        <div style="background:#0d9488;padding:24px 32px;">
+          <h1 style="color:#fff;margin:0;font-size:22px;">⏰ Booking Reminder</h1>
+          <p style="color:#ccfbf1;margin:4px 0 0;">Your appointment is tomorrow</p>
+        </div>
+        <div style="padding:32px;">
+          <p style="font-size:16px;color:#334155;">Hi <strong>${customerName}</strong>,</p>
+          <p style="color:#475569;">This is a reminder that you have a service appointment scheduled for <strong>tomorrow</strong>.</p>
+          <div style="background:#f8fafc;border-left:4px solid #0d9488;border-radius:8px;padding:20px;margin:24px 0;">
+            <table style="width:100%;border-collapse:collapse;">
+              <tr><td style="padding:6px 0;color:#64748b;font-size:14px;">Service</td><td style="padding:6px 0;font-weight:600;color:#0f172a;">${serviceName}</td></tr>
+              <tr><td style="padding:6px 0;color:#64748b;font-size:14px;">Provider</td><td style="padding:6px 0;font-weight:600;color:#0f172a;">${providerName}</td></tr>
+              <tr><td style="padding:6px 0;color:#64748b;font-size:14px;">Date</td><td style="padding:6px 0;font-weight:600;color:#0f172a;">${dateStr}</td></tr>
+              <tr><td style="padding:6px 0;color:#64748b;font-size:14px;">Time</td><td style="padding:6px 0;font-weight:600;color:#0f172a;">${timeStr}</td></tr>
+              ${address ? `<tr><td style="padding:6px 0;color:#64748b;font-size:14px;">Address</td><td style="padding:6px 0;font-weight:600;color:#0f172a;">${address}</td></tr>` : ''}
+            </table>
+          </div>
+          <p style="color:#475569;font-size:14px;">Please make sure someone is available at the address during this time.</p>
+          <p style="color:#94a3b8;font-size:13px;margin-top:32px;">— The ServiceHub Team</p>
+        </div>
+      </div>
+    </body>
+    </html>
+  `;
+
+  return await sendEmail({
+    to,
+    subject: `Reminder: ${serviceName} appointment tomorrow at ${timeStr}`,
+    html,
+    text: `Hi ${customerName}, reminder: ${serviceName} with ${providerName} is tomorrow (${dateStr} at ${timeStr})${address ? ' at ' + address : ''}.`
+  });
+};
+
+export default { sendEmail, sendWelcomeEmail, sendBookingConfirmation, sendBookingReminderEmail };

--- a/backend/src/services/reminderService.js
+++ b/backend/src/services/reminderService.js
@@ -1,0 +1,88 @@
+import cron from 'node-cron';
+import supabase from '../config/supabase.js';
+import { sendBookingReminderEmail } from './emailService.js';
+
+// In-memory dedup: prevents re-sending within the same server session
+const sentReminders = new Set();
+
+/**
+ * Query confirmed bookings in the 23.5–24.5 hour window and send reminder emails.
+ * Safe to call multiple times — sentReminders guards against duplicates.
+ */
+export async function checkAndSendReminders() {
+  const now = Date.now();
+  const windowStart = new Date(now + 23.5 * 3600_000).toISOString();
+  const windowEnd   = new Date(now + 24.5 * 3600_000).toISOString();
+
+  const { data: bookings, error } = await supabase
+    .from('bookings')
+    .select(`
+      id, scheduled_at,
+      address_street, address_city, address_state, address_zip,
+      customer:users!bookings_customer_id_fkey(email, full_name),
+      service:services(name),
+      provider:providers(business_name)
+    `)
+    .eq('status', 'confirmed')
+    .gte('scheduled_at', windowStart)
+    .lte('scheduled_at', windowEnd);
+
+  if (error) {
+    console.error('❌ Reminder query error:', error.message);
+    return { sent: 0, errors: 1 };
+  }
+
+  // Build send tasks — skip already-sent and bookings without a customer email
+  const tasks = (bookings ?? [])
+    .filter(b => !sentReminders.has(b.id) && b.customer?.email)
+    .map(booking => {
+      const addressParts = [
+        booking.address_street,
+        booking.address_city,
+        booking.address_state,
+        booking.address_zip,
+      ].filter(Boolean);
+
+      return sendBookingReminderEmail({
+        to:           booking.customer.email,
+        customerName: booking.customer.full_name      || 'Customer',
+        serviceName:  booking.service?.name           || 'Service',
+        providerName: booking.provider?.business_name || 'Provider',
+        scheduledAt:  booking.scheduled_at,
+        address:      addressParts.join(', '),
+      }).then(result => ({ booking, result }));
+    });
+
+  const outcomes = await Promise.allSettled(tasks);
+  let sent = 0;
+  let errors = 0;
+
+  for (const outcome of outcomes) {
+    if (outcome.status === 'rejected') { errors++; continue; }
+    const { booking, result } = outcome.value;
+    if (result.success) {
+      sentReminders.add(booking.id);
+      sent++;
+      console.log(`  ✅ Reminder sent → booking ${booking.id.slice(0, 8)} (${booking.customer.email})`);
+    } else {
+      errors++;
+      console.error(`  ❌ Reminder failed → booking ${booking.id.slice(0, 8)}: ${result.error}`);
+    }
+  }
+
+  console.log(`🔔 Reminder run complete — sent: ${sent}, errors: ${errors}, window: ${windowStart} → ${windowEnd}`);
+  return { sent, errors };
+}
+
+/**
+ * Starts the cron job. Call once on server startup (skipped in test env).
+ * Schedule: every 15 minutes.
+ */
+export function startReminderCron() {
+  cron.schedule('*/15 * * * *', () => {
+    checkAndSendReminders().catch(err =>
+      console.error('❌ Reminder cron unhandled error:', err)
+    );
+  });
+  console.log('🔔 Booking reminder cron started (runs every 15 min)');
+}


### PR DESCRIPTION
## Jira
[SER-125](https://njit-servicehub.atlassian.net/browse/SER-125) — 24hr Booking Reminder Email

## What changed
- `reminderService.js` (new) — `node-cron` job runs every 15 min, queries confirmed bookings in the 23.5–24.5hr window, sends reminder emails
- `emailService.js` — added `sendBookingReminderEmail()`; switched transport from Resend to **Gmail/nodemailer** (Resend free tier blocks sending to arbitrary addresses without a verified domain)
- `server.js` — `startReminderCron()` called on boot, gated by `NODE_ENV !== 'test'`
- `testRoutes.js` — `POST /api/test/trigger-reminders` and `POST /api/test/send-reminder/:bookingId` for manual testing
- `package.json` — added `node-cron`, replaced `resend` with `nodemailer`

## Email config
- Transport: Gmail SMTP via App Password
- FROM: `ServiceHub <hub93024@gmail.com>`
- Credentials: `GMAIL_USER` + `GMAIL_APP_PASSWORD` in `.env`

## Test
```bash
# Force-send for a specific confirmed booking
curl -X POST http://localhost:3000/api/test/send-reminder/<bookingId>

# Trigger cron window check (returns sent:0 unless booking is ~24hr out)
curl -X POST http://localhost:3000/api/test/trigger-reminders
```