### PR TITLE
feat(SER-83, SER-82): paginated provider reviews + service reviews on browse page

### DIFF
--- a/CLAUDE_CONTEXT.md
+++ b/CLAUDE_CONTEXT.md
@@ -1,0 +1,236 @@
+# ServiceHub — Claude Session Context & Handoff
+
+> **Last updated:** April 30, 2026 (Session 2)
+> **Session owner:** Deep Talreja (dt443@njit.edu)
+> **Purpose:** Full handoff context so any new Claude session can resume exactly where this one left off.
+
+---
+
+## 1. Project Overview
+
+**ServiceHub** — a home-service marketplace (cleaning, plumbing, electrical, pest control).  
+Customers browse service providers, book slots, and leave reviews.  
+Providers manage bookings via a dashboard.
+
+### Stack
+| Layer | Tech |
+|---|---|
+| Frontend | React 18 + TypeScript + Vite + Tailwind CSS |
+| Backend | Node.js + Express.js |
+| Database | Supabase (PostgreSQL + Auth + Storage) |
+| AI Services | FastAPI (Python) + Docker — visual damage assessment |
+| Auth | Supabase JWT |
+| CI/CD | GitHub Actions |
+
+### Repo
+```
+https://github.com/ShriyaSharma1122334455/Service-Hub-A-Home-Service-Market-Place-
+```
+
+### Local paths
+```
+Project root:   /Users/deep_anmol/Desktop/ServiceHub_Deep/ServiceHub_Shriya/
+Frontend:       .../frontend/src/
+Backend:        .../backend/src/
+Frontend URL:   http://localhost:5173
+Backend URL:    http://localhost:3000
+```
+
+---
+
+## 2. Current Sprint: Final Week — Sprint 6 (Deadline May 1, 2026)
+
+This is the LAST sprint. All features must be completed, tested, and submitted.
+
+---
+
+## 3. All PRs by Deep Talreja (full history)
+
+| PR | Branch | Status | Description |
+|---|---|---|---|
+| #70 | `fix/issue-54-pagination-count` | ✅ Merged | Pagination count fix |
+| #71 | `feat/ser-113-service-provider-info` | ✅ Merged | Service catalog category cards |
+| #72 | `feat/ser-123-provider-reviews` | ✅ Merged | Reviews section on provider profile |
+| #73 | `feat/ser-132-chatbot-real-bookings` | ✅ Merged | Chatbot real booking data |
+| #77 | `feat/ser-122-submit-review` | ✅ Merged | Submit review form + bugfixes |
+| **—** | `feat/ser-125-booking-reminder` | 🟡 **Open — needs PR** | 24hr reminder email (SER-125) |
+| **—** | `feat/ser-83-82-reviews-pagination` | 🟡 **Open — needs PR** | Pagination + service reviews (SER-83, SER-82) |
+
+---
+
+## 4. Latest main branch state (as of Apr 30, 2026)
+
+Most recent PRs merged to main (newest first): #91, #90, #89, #87, #86, #83, #77, #74, #73, #72, #71, #70
+
+Main is at commit `b2df9da` (PR #91 — customer details in booking responses).
+
+---
+
+## 5. Jira Task Status — Deep Talreja
+
+### ✅ COMPLETED
+SER-12, SER-20, SER-34, SER-38, SER-60, SER-61, SER-66, SER-79, SER-80, SER-81, SER-122, SER-123, SER-132, SER-147, SER-148, SER-149, SER-150, SER-151, SER-179, SER-180, SER-181
+
+### ✅ DONE THIS SESSION (Apr 30)
+| Ticket | Summary | Branch |
+|---|---|---|
+| SER-125 | 24hr booking reminder email | `feat/ser-125-booking-reminder` |
+| SER-83 | Pagination for reviews | `feat/ser-83-82-reviews-pagination` |
+| SER-82 | Fetch reviews by service | `feat/ser-83-82-reviews-pagination` |
+
+### ⚠️ JIRA STATUS WRONG — update in Jira
+| Ticket | Jira Says | Actual |
+|---|---|---|
+| SER-39 | In Progress | ✅ Done — code in PR #72 |
+
+### ❌ SKIPPED / NOT APPLICABLE
+- SER-182: Assigned to Akash, he is doing it
+- SER-167/168/169: Subtasks of SER-125, now done via the cron implementation
+
+---
+
+## 6. What Was Built This Session (Apr 30)
+
+### SER-125: 24hr Booking Reminder Email
+
+**Files changed:**
+- `backend/src/services/emailService.js` — `sendBookingReminderEmail()` added
+- `backend/src/services/reminderService.js` — **NEW**: cron query + email dispatch
+- `backend/src/server.js` — `startReminderCron()` called on boot
+- `backend/src/routes/testRoutes.js` — two test endpoints added
+- `backend/package.json` — `node-cron` dependency added
+
+**How it works:**
+- Cron runs every 15 minutes via `node-cron`
+- Queries `bookings` where `status = 'confirmed'` AND `scheduled_at` is between `NOW + 23.5hr` and `NOW + 24.5hr`
+- Sends branded HTML email via Resend
+- In-memory Set prevents duplicate sends within the same server session
+
+**Email details:**
+- Service: **Resend** (`resend.com`)
+- FROM: `ServiceHub <onboarding@resend.dev>` (configured in `backend/.env`)
+- TO: the customer's email from the bookings table
+- RESEND_API_KEY is already set in `backend/.env`
+
+**Test endpoints (dev only):**
+```bash
+# Trigger the cron check manually (uses current time window)
+curl -X POST http://localhost:3000/api/test/trigger-reminders
+
+# Force-send for a specific booking ID (ignores time window)
+curl -X POST http://localhost:3000/api/test/send-reminder/<bookingId>
+```
+
+### SER-83: Pagination for Reviews
+
+**Files changed:**
+- `backend/src/controllers/reviewController.js` — `getProviderReviews` now accepts `?page=&limit=`
+- `frontend/src/pages/Profile.tsx` — Prev/Next pagination UI, page state, total count
+- `backend/src/scripts/seedReviews.js` — **NEW**: seeds 15 reviews for Deep Clean Pro
+
+**API change:**
+```
+GET /api/reviews/:providerId?page=1&limit=5
+Response: { success, data: { reviews: [...], count: 15, totalPages: 3, page: 1 } }
+```
+
+**Seed data inserted:** 15 completed bookings + 15 reviews for Deep Clean Pro  
+Provider avg updated to **4.31★** (16 total reviews including 1 pre-existing)
+
+### SER-82: Fetch Reviews by Service
+
+**Files changed:**
+- `backend/src/controllers/reviewController.js` — `getServiceReviews()` added
+- `backend/src/routes/reviewRoutes.js` — `GET /api/reviews/service/:serviceId` added
+- `frontend/src/pages/ServiceProviders.tsx` — "What customers say" section added
+
+**API:**
+```
+GET /api/reviews/service/:serviceId?limit=10
+Response: { success, data: { reviews: [...], count: N, avgRating: 4.3 } }
+```
+
+---
+
+## 7. Test Accounts
+
+| Email | Password | Role |
+|---|---|---|
+| `deep_user1@yopmail.com` | `TestPass123!` | Customer |
+| `deep_plumber@yopmail.com` | `TestPass123!` | Provider |
+
+### Key UUIDs
+| Entity | UUID |
+|---|---|
+| Deep Clean Pro (provider) | `58239207-aec2-4d80-955a-bc450d78a903` |
+| Deep Plumber Services (provider) | `e70895b3-c86f-4f43-b63a-7229126a109d` |
+| Drain Cleaning (service) | `c7c72cd1-b811-423c-a555-27a91cf2ec07` |
+| Deep Clean (service) | `2be5a06d-4818-4fe5-9bfc-c664e5540456` |
+| Insect Removal (service) | `4e29444f-cacf-4d2a-8998-d5458a6480c4` |
+
+---
+
+## 8. Critical Architecture Notes
+
+### fetchApi() behaviour — DO NOT get this wrong
+```ts
+return { success: true, data: data.data || data };
+// fetchApi ALREADY unwraps .data from the response body.
+// For paginated reviews, backend returns { success, data: { reviews, totalPages, ... } }
+// → fetchApi returns { success, data: { reviews, totalPages, ... } }
+// Access: res.data.reviews, res.data.totalPages
+```
+
+### Routing (hash-based)
+- `/#/book/:serviceId` — ServiceProviders page (now shows service reviews at bottom)
+- `/#/profile/:id?type=provider` — Provider profile (now has pagination)
+
+### bookingController now blocks unverified providers
+As of PR #89+, `POST /api/bookings` returns 403 if `provider.verification_status !== 'verified'`.  
+Seed scripts bypass this (they write directly to Supabase, not through the API).
+
+### Cron not running in `NODE_ENV=test`
+`startReminderCron()` and `checkSupabaseConnection()` are both gated by `process.env.NODE_ENV !== 'test'`.
+
+---
+
+## 9. Next Steps for Next Session
+
+1. **Open PR for `feat/ser-125-booking-reminder`** — ready to merge
+2. **Open PR for `feat/ser-83-82-reviews-pagination`** — ready to merge
+3. **Update Jira**: mark SER-39 as Done
+4. **Smoke test**: run both servers, go through the feature checklist in LOCAL_RUN_GUIDE.txt
+5. **Email test**: restart backend, then `curl -X POST http://localhost:3000/api/test/send-reminder/<any-bookingId-from-DB>`
+
+---
+
+## 10. Useful Commands
+
+```bash
+cd /Users/deep_anmol/Desktop/ServiceHub_Deep/ServiceHub_Shriya
+
+# Start backend (new terminal)
+cd backend && npm run dev
+
+# Start frontend (new terminal)
+cd frontend && npm run dev
+
+# Seed reviews (15 reviews for Deep Clean Pro — only run once)
+cd backend && npm run seed:reviews
+
+# Test reminder email — force-send for a specific booking
+curl -X POST http://localhost:3000/api/test/send-reminder/<bookingId>
+
+# Test reminder cron window manually
+curl -X POST http://localhost:3000/api/test/trigger-reminders
+
+# Test paginated reviews API
+curl "http://localhost:3000/api/reviews/58239207-aec2-4d80-955a-bc450d78a903?page=1&limit=5"
+
+# Test service reviews API
+curl "http://localhost:3000/api/reviews/service/c7c72cd1-b811-423c-a555-27a91cf2ec07"
+```
+
+---
+
+*Context last updated April 30, 2026 — SER-125, SER-83, SER-82 implemented and pushed.*

--- a/LOCAL_RUN_GUIDE.txt
+++ b/LOCAL_RUN_GUIDE.txt
@@ -1,0 +1,220 @@
+================================================================================
+  SERVICEHUB — LOCAL RUN & MANUAL TESTING GUIDE
+  Last updated: Apr 30, 2026
+================================================================================
+
+--------------------------------------------------------------------------------
+STEP 1 — OPEN PROJECT IN VSCODE
+--------------------------------------------------------------------------------
+
+1. Open VSCode
+2. File > Open Folder > select:
+   /Users/deep_anmol/Desktop/ServiceHub_Deep/ServiceHub_Shriya
+
+--------------------------------------------------------------------------------
+STEP 2 — OPEN TWO TERMINALS IN VSCODE (Terminal > New Terminal, split it)
+--------------------------------------------------------------------------------
+
+TERMINAL 1 — Backend
+---------------------
+  cd backend
+  npm install          (only needed first time or after pulling new changes)
+  npm run dev
+
+  Expected output:
+    🔔 Booking reminder cron started (runs every 15 min)
+    🚀 Server is running on port 3000
+    ✅ Supabase connected successfully
+
+  Backend URL: http://localhost:3000
+
+
+TERMINAL 2 — Frontend
+----------------------
+  cd frontend
+  npm install          (only needed first time or after pulling new changes)
+  npm run dev
+
+  Expected output:
+    VITE ready in ~500ms
+    ➜ Local: http://localhost:5173/
+
+  Frontend URL: http://localhost:5173
+
+
+--------------------------------------------------------------------------------
+STEP 3 — TEST ACCOUNTS & CREDENTIALS
+--------------------------------------------------------------------------------
+
+All accounts use password: TestPass123!
+
+CUSTOMER ACCOUNTS
+  deep_user1@yopmail.com    TestPass123!    (primary test customer)
+  deep_user2@yopmail.com    TestPass123!    (secondary customer)
+
+PROVIDER ACCOUNTS (log in as provider to manage bookings)
+  deep_plumber@yopmail.com      TestPass123!    → Deep Plumber Services
+  deep_cleaner@yopmail.com      TestPass123!    → Deep Clean Pro
+  deep_electrical@yopmail.com   TestPass123!    → Deep Electrical Solutions
+  deep_pest@yopmail.com         TestPass123!    → Deep Pest Control
+
+GENERIC TEST ACCOUNTS (from seed data, limited data)
+  user@test.com         TestPass123!    Customer
+  provider@test.com     TestPass123!    Provider
+
+
+--------------------------------------------------------------------------------
+STEP 4 — MANUAL FEATURE TESTING CHECKLIST
+--------------------------------------------------------------------------------
+
+Open http://localhost:5173 in your browser for all tests below.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 1 — Browse Services by Category
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. Go to http://localhost:5173
+2. You should see category cards (Plumbing, Cleaning, Electrical, Pest Control…)
+3. Click any category — should show a list of providers for that category
+4. Each provider card should show: name, rating, price, description
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 2 — Provider Profile & Reviews (with Pagination)  [SER-83]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Direct URL:
+  http://localhost:5173/#/profile/58239207-aec2-4d80-955a-bc450d78a903?type=provider
+
+(This is Deep Clean Pro — 16 reviews seeded, avg 4.31 stars)
+
+1. Page loads showing provider details and list of services offered
+2. Scroll to Reviews section — should show 5 reviews and header "16 Reviews"
+3. Pagination footer visible: "← Prev  |  Page 1 of 4  |  Next →"
+4. Click Next → — loads reviews 6-10
+5. Click Next → again — loads reviews 11-15
+6. Click Next → again — loads review 16 (last page)
+7. Click Prev ← — goes back to page 3
+8. On page 1, Prev button should be disabled (greyed out)
+9. On last page, Next button should be disabled
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 3 — Service-Level Reviews on Browse Page  [SER-82]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Direct URL (Drain Cleaning service — 15 seeded reviews):
+  http://localhost:5173/#/book/c7c72cd1-b811-423c-a555-27a91cf2ec07
+
+1. Page shows list of providers offering Drain Cleaning
+2. Scroll to bottom — "What customers say" section appears
+3. Should show avg rating badge (e.g. ★ 4.3) and count ("15 reviews")
+4. Review cards in a 2-column grid: reviewer name, stars, comment, date
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 4 — Book a Service
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. Log in as customer: deep_user1@yopmail.com / TestPass123!
+2. Browse to any category and pick a provider
+3. Click "Book Now"
+4. Fill in: date/time (pick tomorrow), address, notes
+5. Submit — should see booking confirmation
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 5 — Submit a Review
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. Log in as customer: deep_user1@yopmail.com / TestPass123!
+2. Go to My Bookings — find a completed booking
+3. Click "Leave a Review" on a completed booking
+4. Give a star rating + comment, submit
+5. Review should appear immediately on that provider's profile page
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 6 — Provider Dashboard (manage bookings)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. Log in as provider: deep_plumber@yopmail.com / TestPass123!
+2. Go to Dashboard
+3. Should see incoming bookings with customer details
+4. Accept or reject a pending booking — status should update
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 7 — Chatbot
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. Log in as customer: deep_user1@yopmail.com / TestPass123!
+2. Click the chat icon (bottom-right)
+3. Ask: "What are my upcoming bookings?"
+4. Bot should respond with real booking data from your account
+5. Ask: "What services do you offer?" — should list categories
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 8 — 24hr Booking Reminder Email  [SER-125]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+In Terminal 1 (backend must be running), paste this in a new terminal tab:
+
+  curl -X POST "http://localhost:3000/api/test/send-reminder/d84d5ec0-880f-4934-a727-3768a4726ba8?to=ad2386@njit.edu"
+
+Expected response: {"success":true,"emailId":"..."}
+
+Check inbox at: ad2386@njit.edu
+Email subject: "Reminder: <Service Name> appointment tomorrow at <time>"
+
+NOTE: Resend free tier only delivers to the registered account email (ad2386@njit.edu).
+      In production with a verified domain, it would go to the actual customer's email.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 9 — Customer Booking History
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. Log in as deep_user1@yopmail.com
+2. Go to My Bookings
+3. Should show past and upcoming bookings with status labels
+4. Pagination should work if more than one page
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FEATURE 10 — Auth (Register / Login / Logout)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+1. Log out if logged in
+2. Register a new customer account with any email
+3. Log out
+4. Log back in with same credentials — should work
+5. Try wrong password — should show error
+6. Try logging in as a provider with provider credentials
+
+
+--------------------------------------------------------------------------------
+STEP 5 — QUICK API HEALTH CHECKS (optional, in any terminal)
+--------------------------------------------------------------------------------
+
+# Backend alive?
+curl http://localhost:3000/api/health
+
+# Paginated provider reviews (Deep Clean Pro, page 1 of 4)
+curl "http://localhost:3000/api/reviews/58239207-aec2-4d80-955a-bc450d78a903?page=1&limit=5"
+
+# Service-level reviews (Drain Cleaning)
+curl "http://localhost:3000/api/reviews/service/c7c72cd1-b811-423c-a555-27a91cf2ec07"
+
+# Cron reminder check (uses real 24hr window — returns sent:0 unless booking exists ~24hr out)
+curl -X POST http://localhost:3000/api/test/trigger-reminders
+
+# Force-send reminder email to your inbox
+curl -X POST "http://localhost:3000/api/test/send-reminder/d84d5ec0-880f-4934-a727-3768a4726ba8?to=ad2386@njit.edu"
+
+
+--------------------------------------------------------------------------------
+KEY URLS REFERENCE
+--------------------------------------------------------------------------------
+
+Frontend home:          http://localhost:5173
+Backend health:         http://localhost:3000/api/health
+
+Deep Clean Pro profile: http://localhost:5173/#/profile/58239207-aec2-4d80-955a-bc450d78a903?type=provider
+Drain Cleaning browse:  http://localhost:5173/#/book/c7c72cd1-b811-423c-a555-27a91cf2ec07
+Deep Clean browse:      http://localhost:5173/#/book/2be5a06d-4818-4fe5-9bfc-c664e5540456
+
+
+--------------------------------------------------------------------------------
+NOTES
+--------------------------------------------------------------------------------
+
+- If backend shows old behavior after git pull: kill the terminal and re-run npm run dev
+- Seed reviews (only needed once, already done):
+    cd backend && npm run seed:reviews
+- Node version required: >= 18
+- Both servers must be running at the same time for the site to work
+
+================================================================================

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -64,11 +64,23 @@ export const createReview = async (req, res) => {
   }
 };
 
-// GET /api/reviews/:providerId
+// GET /api/reviews/:providerId?page=1&limit=5
 export const getProviderReviews = async (req, res) => {
   try {
     const { providerId } = req.params;
+    const page  = Math.max(1, parseInt(req.query.page)  || 1);
+    const limit = Math.min(50, Math.max(1, parseInt(req.query.limit) || 5));
+    const offset = (page - 1) * limit;
 
+    // Total count (cheap head-only request)
+    const { count, error: countErr } = await supabase
+      .from('reviews')
+      .select('*', { count: 'exact', head: true })
+      .eq('provider_id', providerId);
+
+    if (countErr) return res.status(400).json({ success: false, error: countErr.message });
+
+    // Page of reviews
     const { data: reviews, error } = await supabase
       .from('reviews')
       .select(`
@@ -76,15 +88,69 @@ export const getProviderReviews = async (req, res) => {
         reviewer:users(full_name, avatar_url)
       `)
       .eq('provider_id', providerId)
-      .order('created_at', { ascending: false });
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
 
     if (error) return res.status(400).json({ success: false, error: error.message });
 
-    return res.json({ success: true, count: reviews.length, data: reviews });
+    const totalPages = Math.ceil((count || 0) / limit);
+
+    // Return under .data so fetchApi keeps the pagination envelope intact
+    return res.json({
+      success: true,
+      data: { reviews, count: count || 0, totalPages, page },
+    });
 
   } catch (err) {
     console.error('getProviderReviews error:', err);
     res.status(500).json({ success: false, error: 'Failed to fetch reviews' });
+  }
+};
+
+// GET /api/reviews/service/:serviceId?limit=10
+export const getServiceReviews = async (req, res) => {
+  try {
+    const { serviceId } = req.params;
+    const limit = Math.min(50, Math.max(1, parseInt(req.query.limit) || 10));
+
+    // Resolve booking IDs that belong to this service
+    const { data: bookings, error: bErr } = await supabase
+      .from('bookings')
+      .select('id')
+      .eq('service_id', serviceId);
+
+    if (bErr) return res.status(400).json({ success: false, error: bErr.message });
+
+    if (!bookings?.length) {
+      return res.json({ success: true, data: { reviews: [], count: 0, avgRating: 0 } });
+    }
+
+    const bookingIds = bookings.map(b => b.id);
+
+    const { data: reviews, count, error } = await supabase
+      .from('reviews')
+      .select(`
+        id, rating, comment, created_at,
+        reviewer:users(full_name, avatar_url)
+      `, { count: 'exact' })
+      .in('booking_id', bookingIds)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error) return res.status(400).json({ success: false, error: error.message });
+
+    const avgRating = reviews?.length
+      ? Math.round((reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length) * 10) / 10
+      : 0;
+
+    return res.json({
+      success: true,
+      data: { reviews: reviews || [], count: count || 0, avgRating },
+    });
+
+  } catch (err) {
+    console.error('getServiceReviews error:', err);
+    res.status(500).json({ success: false, error: 'Failed to fetch service reviews' });
   }
 };
 

--- a/backend/src/routes/reviewRoutes.js
+++ b/backend/src/routes/reviewRoutes.js
@@ -1,10 +1,13 @@
 import express from 'express';
-import { createReview, getProviderReviews } from '../controllers/reviewController.js';
+import { createReview, getProviderReviews, getServiceReviews } from '../controllers/reviewController.js';
 import { authenticate } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
-// Public — anyone can read reviews for a provider
+// Public — service-level aggregate reviews (must be before /:providerId to avoid param clash)
+router.get('/service/:serviceId', getServiceReviews);
+
+// Public — paginated reviews for a provider (?page=1&limit=5)
 router.get('/:providerId', getProviderReviews);
 
 // Authenticated — only logged-in customers can submit a review

--- a/backend/src/scripts/seedReviews.js
+++ b/backend/src/scripts/seedReviews.js
@@ -1,0 +1,174 @@
+/**
+ * seedReviews.js
+ *
+ * Seeds 15 reviews for Deep Clean Pro so pagination (SER-83) can be tested.
+ * Creates completed bookings first (bypasses the API), then inserts reviews.
+ *
+ * Run: node src/scripts/seedReviews.js
+ *
+ * Safe to re-run — uses upsert on bookings and skips existing reviews.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const REVIEW_FIXTURES = [
+  { rating: 5, comment: 'Absolutely amazing service! The team was punctual, thorough, and left everything spotless.' },
+  { rating: 5, comment: 'Best cleaning service I have ever used. Highly recommend to anyone in the area.' },
+  { rating: 4, comment: 'Great job overall. A few spots were missed but they came back and fixed it right away.' },
+  { rating: 5, comment: 'Professional, friendly, and very detailed. Will definitely book again.' },
+  { rating: 3, comment: 'Decent job. Could be a bit more careful with fragile items but nothing was broken.' },
+  { rating: 5, comment: 'Showed up on time and did an outstanding job. My apartment has never been this clean!' },
+  { rating: 4, comment: 'Very satisfied. The price was fair and the quality was excellent.' },
+  { rating: 2, comment: 'Service was okay but not worth the price. Expected more attention to detail.' },
+  { rating: 5, comment: 'I am so impressed. Every corner was cleaned and they even organized my shelves.' },
+  { rating: 4, comment: 'Good experience. The cleaner was polite and efficient. Minor issues with the bathroom.' },
+  { rating: 5, comment: 'Five stars! Fast, professional, and thorough. Booked them again for next month.' },
+  { rating: 3, comment: 'Average cleaning. Got the job done but nothing special.' },
+  { rating: 5, comment: 'Incredible attention to detail. They cleaned places I had forgotten about entirely.' },
+  { rating: 4, comment: 'Very reliable. Third time using them and always consistent quality.' },
+  { rating: 5, comment: 'Worth every penny. My house smells fresh and every surface is spotless.' },
+];
+
+async function main() {
+  console.log('🌱 Seeding reviews for SER-83 pagination testing...\n');
+
+  // 1. Resolve Deep Clean Pro provider
+  const { data: providers, error: pErr } = await supabase
+    .from('providers')
+    .select('id, business_name')
+    .ilike('business_name', '%Deep Clean%')
+    .limit(1);
+
+  if (pErr || !providers?.length) {
+    console.error('❌ Could not find "Deep Clean Pro" provider. Run seedDeepTestData.js first.');
+    process.exit(1);
+  }
+  const provider = providers[0];
+  console.log(`✅ Provider: ${provider.business_name} (${provider.id})`);
+
+  // 2. Resolve customer user IDs
+  const { data: users, error: uErr } = await supabase
+    .from('users')
+    .select('id, email')
+    .in('email', ['deep_user1@yopmail.com', 'deep_user2@yopmail.com']);
+
+  if (uErr || !users?.length) {
+    console.error('❌ Test users not found. Register deep_user1@yopmail.com and deep_user2@yopmail.com first.');
+    process.exit(1);
+  }
+
+  const userMap = {};
+  for (const u of users) userMap[u.email] = u.id;
+  console.log(`✅ Customers: ${Object.keys(userMap).join(', ')}\n`);
+
+  // 3. Resolve a cleaning service
+  const { data: services, error: sErr } = await supabase
+    .from('services')
+    .select('id, name')
+    .ilike('name', '%clean%')
+    .limit(1);
+
+  if (sErr || !services?.length) {
+    console.error('❌ No cleaning service found in DB.');
+    process.exit(1);
+  }
+  const service = services[0];
+  console.log(`✅ Service: ${service.name} (${service.id})\n`);
+
+  // 4. Create 15 completed bookings at different past dates
+  console.log('📅 Inserting completed bookings...');
+  const now = Date.now();
+  const customerIds = [
+    userMap['deep_user1@yopmail.com'],
+    userMap['deep_user2@yopmail.com'],
+  ].filter(Boolean);
+
+  const bookings = REVIEW_FIXTURES.map((_, i) => ({
+    customer_id:    customerIds[i % customerIds.length],
+    provider_id:    provider.id,
+    service_id:     service.id,
+    status:         'completed',
+    scheduled_at:   new Date(now - (i + 1) * 3 * 86_400_000).toISOString(), // 3-day intervals back
+    completed_at:   new Date(now - (i + 1) * 3 * 86_400_000 + 3600_000).toISOString(),
+    total_price:    89,
+    payment_status: 'paid',
+    notes:          `Seed booking #${i + 1} for review pagination testing`,
+    address_street: '100 Broad St',
+    address_city:   'Newark',
+    address_state:  'NJ',
+    address_zip:    '07102',
+  }));
+
+  const { data: insertedBookings, error: bErr } = await supabase
+    .from('bookings')
+    .insert(bookings)
+    .select('id, customer_id');
+
+  if (bErr) {
+    console.error('❌ Failed to insert bookings:', bErr.message);
+    process.exit(1);
+  }
+  console.log(`  ✅ Inserted ${insertedBookings.length} completed bookings\n`);
+
+  // 5. Insert reviews linked to those bookings
+  console.log('⭐ Inserting reviews...');
+  let created = 0;
+  let skipped = 0;
+
+  for (let i = 0; i < insertedBookings.length; i++) {
+    const booking  = insertedBookings[i];
+    const fixture  = REVIEW_FIXTURES[i];
+
+    const { error: rErr } = await supabase
+      .from('reviews')
+      .insert({
+        booking_id:   booking.id,
+        reviewer_id:  booking.customer_id,
+        provider_id:  provider.id,
+        rating:       fixture.rating,
+        comment:      fixture.comment,
+      });
+
+    if (rErr) {
+      if (rErr.code === '23505') {
+        skipped++;
+      } else {
+        console.error(`  ❌ Review ${i + 1} failed: ${rErr.message}`);
+      }
+    } else {
+      created++;
+      console.log(`  ✅ Review ${i + 1}: ${fixture.rating}★ — "${fixture.comment.slice(0, 50)}…"`);
+    }
+  }
+
+  // 6. Refresh provider avg rating
+  const { data: allReviews } = await supabase
+    .from('reviews')
+    .select('rating')
+    .eq('provider_id', provider.id);
+
+  if (allReviews?.length) {
+    const avg = allReviews.reduce((s, r) => s + r.rating, 0) / allReviews.length;
+    await supabase
+      .from('providers')
+      .update({ rating_avg: Math.round(avg * 100) / 100, rating_count: allReviews.length })
+      .eq('id', provider.id);
+    console.log(`\n  ✅ Provider avg updated → ${(Math.round(avg * 100) / 100).toFixed(2)}★ (${allReviews.length} reviews)`);
+  }
+
+  console.log(`\n🎉 Done! Created: ${created}, Skipped (duplicate): ${skipped}`);
+  console.log(`   Test pagination at: GET /api/reviews/${provider.id}?page=1&limit=5\n`);
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -43,7 +43,11 @@ const loginLimiter = rateLimit({
 
 app.use(helmet());
 app.use(cors({
-  origin: process.env.CORS_ORIGIN || 'http://localhost:5173',
+  origin: (origin, callback) => {
+    const allowed = (process.env.CORS_ORIGIN || 'http://localhost:5173,http://localhost:5174').split(',');
+    if (!origin || allowed.includes(origin)) callback(null, true);
+    else callback(new Error(`CORS: origin ${origin} not allowed`));
+  },
   credentials: true
 }));
 app.use(compression());

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -75,6 +75,10 @@ export const Profile: React.FC<ProfileProps> = ({
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [reviews, setReviews] = useState<Review[]>([]);
   const [reviewsLoading, setReviewsLoading] = useState(false);
+  const [reviewsPage, setReviewsPage] = useState(1);
+  const [reviewsTotalPages, setReviewsTotalPages] = useState(1);
+  const [reviewsTotalCount, setReviewsTotalCount] = useState(0);
+  const REVIEWS_PER_PAGE = 5;
 
   // Review form state (only for customers viewing a provider profile)
   const [reviewableBookings, setReviewableBookings] = useState<
@@ -194,7 +198,12 @@ export const Profile: React.FC<ProfileProps> = ({
     };
   }, [profileId, initialType, currentUser, currentUser?.email]);
 
-  // Fetch reviews when a provider profile loads
+  // Reset to page 1 whenever the provider changes
+  useEffect(() => {
+    setReviewsPage(1);
+  }, [profileId]);
+
+  // Fetch reviews when a provider profile loads or page changes
   useEffect(() => {
     if (!profile || profile.type !== "provider") return;
     const providerId = profile.data.id;
@@ -204,21 +213,25 @@ export const Profile: React.FC<ProfileProps> = ({
     const loadReviews = async () => {
       setReviewsLoading(true);
       try {
-        // fetchApi already unwraps `.data` from the response body, so
-        // res.data IS the reviews array directly (not { count, data: [...] }).
-        const res = await fetchApi<Review[]>(`/reviews/${providerId}`);
-        if (!cancelled && res.success) {
-          setReviews(Array.isArray(res.data) ? res.data : []);
+        // Backend returns { reviews, count, totalPages, page } under .data
+        const res = await fetchApi<{
+          reviews: Review[];
+          count: number;
+          totalPages: number;
+          page: number;
+        }>(`/reviews/${providerId}?page=${reviewsPage}&limit=${REVIEWS_PER_PAGE}`);
+        if (!cancelled && res.success && res.data) {
+          setReviews(Array.isArray(res.data.reviews) ? res.data.reviews : []);
+          setReviewsTotalPages(res.data.totalPages ?? 1);
+          setReviewsTotalCount(res.data.count ?? 0);
         }
       } finally {
         if (!cancelled) setReviewsLoading(false);
       }
     };
     loadReviews();
-    return () => {
-      cancelled = true;
-    };
-  }, [profile]);
+    return () => { cancelled = true; };
+  }, [profile, reviewsPage]);
 
   // Fetch the customer's completed bookings for this provider so we can show the review form
   useEffect(() => {
@@ -342,14 +355,17 @@ export const Profile: React.FC<ProfileProps> = ({
       setReviewSuccess(true);
       setReviewRating(0);
       setReviewComment("");
-      // Prepend new review optimistically so user sees it immediately
+      // Go back to page 1 so the new review is visible immediately
+      setReviewsPage(1);
+      setReviewsTotalCount(prev => prev + 1);
       const newReview = res.data as unknown as Review;
+      // Only prepend if already on page 1 (useEffect will re-fetch on page change anyway)
       setReviews((prev) => [
         {
           ...newReview,
           reviewer: { full_name: "You", avatar_url: null },
         },
-        ...prev,
+        ...prev.slice(0, REVIEWS_PER_PAGE - 1),
       ]);
     } else {
       const msg =
@@ -657,9 +673,9 @@ export const Profile: React.FC<ProfileProps> = ({
                     <MessageSquare className="h-5 w-5 text-slate-400" />
                     <h2 className="text-sm font-bold text-slate-400 uppercase tracking-wider">
                       Reviews
-                      {reviews.length > 0 && (
+                      {reviewsTotalCount > 0 && (
                         <span className="ml-2 normal-case font-semibold text-slate-500">
-                          ({reviews.length})
+                          ({reviewsTotalCount})
                         </span>
                       )}
                     </h2>
@@ -684,7 +700,7 @@ export const Profile: React.FC<ProfileProps> = ({
                   )}
 
                   {!reviewsLoading && reviews.length > 0 && (
-                    <div className="space-y-3">
+                    <div className="space-y-3" key={`reviews-page-${reviewsPage}`}>
                       {reviews.map((review) => (
                         <div
                           key={review.id}
@@ -738,6 +754,29 @@ export const Profile: React.FC<ProfileProps> = ({
                           </p>
                         </div>
                       ))}
+                    </div>
+                  )}
+
+                  {/* ── Pagination controls ── */}
+                  {reviewsTotalPages > 1 && (
+                    <div className="flex items-center justify-between mt-4 pt-3 border-t border-slate-100">
+                      <button
+                        disabled={reviewsPage <= 1 || reviewsLoading}
+                        onClick={() => setReviewsPage(p => p - 1)}
+                        className="px-4 py-1.5 text-sm font-semibold rounded-full border border-slate-200 text-slate-600 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                      >
+                        ← Prev
+                      </button>
+                      <span className="text-xs text-slate-400 font-medium">
+                        Page {reviewsPage} of {reviewsTotalPages}
+                      </span>
+                      <button
+                        disabled={reviewsPage >= reviewsTotalPages || reviewsLoading}
+                        onClick={() => setReviewsPage(p => p + 1)}
+                        className="px-4 py-1.5 text-sm font-semibold rounded-full border border-slate-200 text-slate-600 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed transition"
+                      >
+                        Next →
+                      </button>
                     </div>
                   )}
 

--- a/frontend/src/pages/ServiceProviders.tsx
+++ b/frontend/src/pages/ServiceProviders.tsx
@@ -7,6 +7,14 @@ import { ArrowLeft, Star, DollarSign, Clock, ExternalLink } from "lucide-react";
 import type { User } from "../../types";
 import { BookingModal } from "../components/BookingModal";
 
+interface ServiceReview {
+  id: string;
+  rating: number;
+  comment: string | null;
+  created_at: string;
+  reviewer: { full_name: string; avatar_url: string | null } | null;
+}
+
 interface ServiceDetail {
   id: string;
   name: string;
@@ -123,6 +131,11 @@ export const ServiceProviders: React.FC<ServiceProvidersProps> = ({
     providerName: string;
   } | null>(null);
 
+  const [serviceReviews, setServiceReviews] = useState<ServiceReview[]>([]);
+  const [serviceReviewsAvg, setServiceReviewsAvg] = useState(0);
+  const [serviceReviewsCount, setServiceReviewsCount] = useState(0);
+  const [serviceReviewsLoading, setServiceReviewsLoading] = useState(false);
+
   const isCustomer =
     !!user && String(user.role).toLowerCase() === "customer";
 
@@ -171,6 +184,29 @@ export const ServiceProviders: React.FC<ServiceProvidersProps> = ({
 
     load();
     return () => controller.abort();
+  }, [serviceId, API_BASE]);
+
+  // Fetch aggregate reviews for this service (SER-82)
+  useEffect(() => {
+    let cancelled = false;
+    async function loadServiceReviews() {
+      setServiceReviewsLoading(true);
+      try {
+        const res = await fetch(`${API_BASE}/api/reviews/service/${serviceId}?limit=5`);
+        const data = await res.json();
+        if (cancelled || !data.success) return;
+        const payload = data.data ?? {};
+        setServiceReviews(Array.isArray(payload.reviews) ? payload.reviews : []);
+        setServiceReviewsAvg(payload.avgRating ?? 0);
+        setServiceReviewsCount(payload.count ?? 0);
+      } catch {
+        // non-fatal — section just won't render
+      } finally {
+        if (!cancelled) setServiceReviewsLoading(false);
+      }
+    }
+    loadServiceReviews();
+    return () => { cancelled = true; };
   }, [serviceId, API_BASE]);
 
   const categorySlug = service?.categorySlug ?? "";
@@ -366,6 +402,70 @@ export const ServiceProviders: React.FC<ServiceProvidersProps> = ({
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* ── What customers say (SER-82 service-level reviews) ── */}
+      {(serviceReviewsLoading || serviceReviewsCount > 0) && (
+        <div className="mt-8 pb-2">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-base font-bold text-slate-700 flex items-center gap-2">
+              <Star size={16} className="fill-amber-400 text-amber-400" />
+              What customers say
+            </h2>
+            {serviceReviewsCount > 0 && (
+              <div className="flex items-center gap-1.5 text-sm text-slate-500">
+                <span className="font-bold text-slate-800">{serviceReviewsAvg.toFixed(1)}</span>
+                <div className="flex items-center gap-0.5">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Star
+                      key={i}
+                      size={11}
+                      className={i < Math.round(serviceReviewsAvg) ? "fill-amber-400 text-amber-400" : "fill-slate-200 text-slate-200"}
+                    />
+                  ))}
+                </div>
+                <span className="text-xs">({serviceReviewsCount} review{serviceReviewsCount !== 1 ? "s" : ""})</span>
+              </div>
+            )}
+          </div>
+
+          {serviceReviewsLoading && (
+            <div className="flex justify-center py-6">
+              <div className="h-5 w-5 border-2 border-teal-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+
+          {!serviceReviewsLoading && serviceReviews.length > 0 && (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {serviceReviews.map((review) => (
+                <div key={review.id} className="glass-panel rounded-2xl p-4 space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-semibold text-slate-700">
+                      {review.reviewer?.full_name ?? "Customer"}
+                    </span>
+                    <div className="flex items-center gap-0.5">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <Star
+                          key={i}
+                          size={11}
+                          className={i < review.rating ? "fill-amber-400 text-amber-400" : "fill-slate-200 text-slate-200"}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                  {review.comment && (
+                    <p className="text-sm text-slate-600 leading-relaxed line-clamp-3">
+                      {review.comment}
+                    </p>
+                  )}
+                  <p className="text-xs text-slate-400">
+                    {new Date(review.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Jira
- [SER-83](https://njit-servicehub.atlassian.net/browse/SER-83) — Pagination for provider reviews
- [SER-82](https://njit-servicehub.atlassian.net/browse/SER-82) — Fetch reviews by service

## What changed

### SER-83 — Paginated reviews on provider profile
- `reviewController.js` — `getProviderReviews` accepts `?page=&limit=` (default 5, max 50); returns `{ reviews, count, totalPages, page }` so pagination metadata survives `fetchApi`'s `.data` unwrap
- `Profile.tsx` — Prev/Next pagination controls, page state, resets on provider switch
- `seedReviews.js` (new) — seeds 15 reviews for Deep Clean Pro (avg 4.31★, 16 total)

### SER-82 — Service-level reviews on browse page
- `reviewController.js` — added `getServiceReviews()`
- `reviewRoutes.js` — `GET /api/reviews/service/:serviceId` registered before `/:providerId` to avoid param clash
- `ServiceProviders.tsx` — "What customers say" section with avg rating badge + 2-col review grid

### Bug fix
- `server.js` — CORS now accepts both `localhost:5173` and `localhost:5174` (Vite can start on either port depending on what is already in use)

## API
```
GET /api/reviews/:providerId?page=1&limit=5
→ { success, data: { reviews, count, totalPages, page } }

GET /api/reviews/service/:serviceId?limit=10
→ { success, data: { reviews, count, avgRating } }
```

## Test
```bash
# Paginated reviews — Deep Clean Pro (16 reviews, 4 pages)
open http://localhost:5173/#/profile/58239207-aec2-4d80-955a-bc450d78a903?type=provider

# Service reviews — Drain Cleaning (15 seeded reviews)
open http://localhost:5173/#/book/c7c72cd1-b811-423c-a555-27a91cf2ec07
```