### PR TITLE
fix(verification): show DOB in prefill and sanitize user-facing errors

### DIFF
--- a/backend/src/controllers/verificationController.js
+++ b/backend/src/controllers/verificationController.js
@@ -59,7 +59,7 @@ export const getPrefill = async (req, res) => {
 
     const { data: user, error } = await supabase
       .from('users')
-      .select('full_name, email, phone')
+      .select('full_name, email, phone, dob')
       .eq('id', internalUser.id)
       .single();
 
@@ -74,7 +74,7 @@ export const getPrefill = async (req, res) => {
         full_name: user.full_name,
         email: user.email,
         phone: user.phone || null,
-        date_of_birth: null,
+        date_of_birth: user.dob || null,
       },
       error: null,
     });
@@ -213,7 +213,7 @@ export const uploadId = async (req, res) => {
     });
   } catch (err) {
     console.error('uploadId error:', err);
-    return res.status(500).json({ success: false, data: null, error: err.stack || err.message || 'Failed to process ID document' });
+    return res.status(500).json({ success: false, data: null, error: 'Failed to process ID document. Please try again.' });
   }
 };
 

--- a/backend/src/tests/verificationPrefill.test.js
+++ b/backend/src/tests/verificationPrefill.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for Bug-Fix-3:
+ *   VER-PREFILL-01/02 — getPrefill must return date_of_birth from users.dob (Bug A)
+ *   VER-UPLOAD-01     — uploadId 500 must not leak stack traces (Bug B-B2)
+ */
+
+import { jest } from '@jest/globals';
+
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-key';
+process.env.AI_SERVICES_URL = 'http://localhost:8000';
+process.env.AI_INTERNAL_API_KEY = 'test-key';
+
+let supabaseMock;
+
+jest.unstable_mockModule('../config/supabase.js', () => {
+  supabaseMock = { from: jest.fn() };
+  return { default: supabaseMock };
+});
+
+jest.unstable_mockModule('../services/supabaseVerificationStorage.js', () => ({
+  uploadVerificationDocument: jest.fn(),
+  generateVerificationPath: jest.fn().mockReturnValue('test/path.jpg'),
+  getSignedUrl: jest.fn(),
+}));
+
+const { getPrefill, uploadId } = await import('../controllers/verificationController.js');
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const makeChain = (resolveWith) => ({
+  select: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  upsert: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  maybeSingle: jest.fn().mockResolvedValue(resolveWith),
+  single: jest.fn().mockResolvedValue(resolveWith),
+});
+
+describe('getPrefill — Bug A (DOB)', () => {
+  test('VER-PREFILL-01: returns date_of_birth when users.dob is set', async () => {
+    const internalChain = makeChain({
+      data: { id: 'uuid-1', full_name: 'Jane Doe', email: 'jane@test.com', phone: '555-0001', role: 'provider' },
+      error: null,
+    });
+    const prefillChain = makeChain({
+      data: { full_name: 'Jane Doe', email: 'jane@test.com', phone: '555-0001', dob: '1990-03-15' },
+      error: null,
+    });
+
+    supabaseMock.from = jest.fn()
+      .mockReturnValueOnce(internalChain)
+      .mockReturnValueOnce(prefillChain);
+
+    const res = mockRes();
+    await getPrefill({ user: { id: 'supabase-uid' } }, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ date_of_birth: '1990-03-15' }),
+      })
+    );
+  });
+
+  test('VER-PREFILL-02: returns null date_of_birth when dob is null in DB', async () => {
+    const internalChain = makeChain({
+      data: { id: 'uuid-2', full_name: 'Bob', email: 'bob@test.com', phone: null, role: 'provider' },
+      error: null,
+    });
+    const prefillChain = makeChain({
+      data: { full_name: 'Bob', email: 'bob@test.com', phone: null, dob: null },
+      error: null,
+    });
+
+    supabaseMock.from = jest.fn()
+      .mockReturnValueOnce(internalChain)
+      .mockReturnValueOnce(prefillChain);
+
+    const res = mockRes();
+    await getPrefill({ user: { id: 'supabase-uid-2' } }, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ date_of_birth: null }),
+      })
+    );
+  });
+});
+
+describe('uploadId — Bug B-B2 (no stack trace leak)', () => {
+  test('VER-UPLOAD-01: 500 body does not contain stack trace or raw error message', async () => {
+    const dbErr = new Error('DB connection failed');
+    dbErr.stack = 'Error: DB connection failed\n    at Object.<anonymous> (verificationController.js:30)';
+    supabaseMock.from = jest.fn().mockImplementation(() => { throw dbErr; });
+
+    const req = {
+      user: { id: 'supabase-uid' },
+      file: { mimetype: 'image/jpeg', size: 1000, buffer: Buffer.from('x'), originalname: 'id.jpg' },
+      body: { documentType: 'drivers_license' },
+    };
+    const res = mockRes();
+    await uploadId(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    const body = res.json.mock.calls[0][0];
+    const serialised = JSON.stringify(body);
+    expect(serialised).not.toMatch(/at Object\./);
+    expect(serialised).not.toMatch(/DB connection failed/);
+    expect(body.error).toBe('Failed to process ID document. Please try again.');
+  });
+});

--- a/frontend/src/components/VerificationDetailsModal.tsx
+++ b/frontend/src/components/VerificationDetailsModal.tsx
@@ -49,6 +49,15 @@ interface VerificationData {
   created_at?: string;
 }
 
+const STATUS_LABELS: Record<string, string> = {
+  verified: "Verified",
+  pending: "Under Review",
+  manual_review: "Under Manual Review",
+  rejected: "Not Verified",
+  failed: "Not Verified",
+  unverified: "Not Verified",
+};
+
 const StatusIcon: React.FC<{ status?: string }> = ({ status }) => {
   switch (status) {
     case "verified":
@@ -155,8 +164,8 @@ export const VerificationDetailsModal: React.FC<
                     ${data.verification_status === "unverified" ? "bg-slate-100 text-slate-600" : ""}`}
                 >
                   <StatusIcon status={data.verification_status} />
-                  {data.verification_status.charAt(0).toUpperCase() +
-                    data.verification_status.slice(1)}
+                  {STATUS_LABELS[data.verification_status] ??
+                    data.verification_status}
                 </span>
               </div>
 

--- a/frontend/src/pages/verify/index.tsx
+++ b/frontend/src/pages/verify/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import fetchApi from "../../lib/api";
 import { supabase } from "../../lib/supabase";
+import { toUserMessage } from "../../utils/errorMessages";
 import {
   Camera,
   Upload,
@@ -159,7 +160,7 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
         setError(json.error || "Failed to upload ID document.");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Network error");
+      setError(toUserMessage(err));
     } finally {
       setLoading(false);
     }
@@ -261,7 +262,7 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
         setError(json.error || "Failed to upload selfie.");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Network error");
+      setError(toUserMessage(err));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/utils/errorMessages.ts
+++ b/frontend/src/utils/errorMessages.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function toUserMessage(_err: unknown): string {
+  return "Something went wrong while uploading. Please check your connection and try again.";
+}


### PR DESCRIPTION
## Summary
- Bug A: GET /verification/prefill now returns the stored date_of_birth instead of always null
- Bug B-B2: uploadId 500 response no longer leaks err.stack or raw JS error messages
- Bug B-B1: Upload catch blocks now show a safe string via toUserMessage() instead of raw TypeError message
- Bug B-B3: Status modal uses STATUS_LABELS map — manual_review shows 'Under Manual Review' instead of 'Manual_review'

## Test plan
- [x] 3 new Jest tests pass: VER-PREFILL-01, VER-PREFILL-02, VER-UPLOAD-01 (full suite 167/167)
- [x] Frontend build and lint clean
- [ ] Register with a DOB, open verification form, DOB field pre-filled
- [ ] Disconnect network, start upload, see safe error message not 'Failed to fetch'
- [ ] Verification modal shows 'Under Manual Review' not 'Manual_review'

Note: server.js dev-mode stack trace leak deferred to Bug-Fix-4 (out of scope).

Generated with Claude Code