### PR TITLE
listUsers scope · review role guard · fallback slot banner

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -142,10 +142,16 @@ export const getUser = async (req, res) => {
 
 export const listUsers = async (req, res) => {
   try {
-    const { data: users, error } = await supabase
+    // Optional ?role=customer|provider|admin filter. No filter = all users.
+    const roleFilter = req.query.role || null;
+
+    let query = supabase
       .from('users')
-      .select('id, supabase_id, full_name, avatar_url, role, email, verification_status')
-      .eq('role', 'customer');
+      .select('id, supabase_id, full_name, avatar_url, role, email, verification_status');
+
+    if (roleFilter) query = query.eq('role', roleFilter);
+
+    const { data: users, error } = await query;
 
     if (error) {
       return res.status(400).json({ success: false, error: error.message });

--- a/backend/src/routes/reviewRoutes.js
+++ b/backend/src/routes/reviewRoutes.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { createReview, getProviderReviews, getServiceReviews } from '../controllers/reviewController.js';
-import { authenticate } from '../middleware/authMiddleware.js';
+import { authenticate, requireRole } from '../middleware/authMiddleware.js';
 
 const router = express.Router();
 
@@ -10,7 +10,7 @@ router.get('/service/:serviceId', getServiceReviews);
 // Public — paginated reviews for a provider (?page=1&limit=5)
 router.get('/:providerId', getProviderReviews);
 
-// Authenticated — only logged-in customers can submit a review
-router.post('/', authenticate, createReview);
+// Authenticated — only customers can submit a review
+router.post('/', authenticate, requireRole('customer'), createReview);
 
 export default router;

--- a/frontend/src/components/BookingModal.tsx
+++ b/frontend/src/components/BookingModal.tsx
@@ -120,6 +120,8 @@ export const BookingModal: React.FC<BookingModalProps> = ({
   // Submission
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Tracks whether displayed slots are real provider slots or generated fallbacks
+  const [usedFallback, setUsedFallback] = useState(false);
 
   useEffect(() => {
     const p = readDamagePrefill();
@@ -137,6 +139,7 @@ export const BookingModal: React.FC<BookingModalProps> = ({
       setSlotsLoading(true);
       setSlots([]);
       setSelectedSlot(null);
+      setUsedFallback(false);
       const dateStr = toLocalDate(selectedDate!);
       try {
         const res = await fetch(
@@ -156,13 +159,18 @@ export const BookingModal: React.FC<BookingModalProps> = ({
               endTime: s.end_time,
               label: `${fmt12h(s.start_time)} – ${fmt12h(s.end_time)}`,
             }));
+          setUsedFallback(false);
           setSlots(available);
         } else {
           // No availability endpoint yet — fall back to generated slots
+          setUsedFallback(true);
           setSlots(generateFallbackSlots());
         }
       } catch {
-        if (!controller.signal.aborted) setSlots(generateFallbackSlots());
+        if (!controller.signal.aborted) {
+          setUsedFallback(true);
+          setSlots(generateFallbackSlots());
+        }
       } finally {
         if (!controller.signal.aborted) setSlotsLoading(false);
       }
@@ -366,7 +374,16 @@ export const BookingModal: React.FC<BookingModalProps> = ({
                   No slots available on this date. Try another day.
                 </p>
               ) : (
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                <>
+                  {usedFallback && (
+                    <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-xl px-3 py-2.5 mb-2 text-xs text-amber-800">
+                      <span className="mt-0.5">⚠️</span>
+                      <span>
+                        <span className="font-bold">Suggested times only</span> — this provider hasn't set specific availability. These are general windows. The provider will confirm your chosen time after booking.
+                      </span>
+                    </div>
+                  )}
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                   {slots.map((slot) => (
                     <button
                       key={slot.id}
@@ -384,6 +401,7 @@ export const BookingModal: React.FC<BookingModalProps> = ({
                     </button>
                   ))}
                 </div>
+                </>
               )}
             </section>
           )}


### PR DESCRIPTION
## Summary
Fixes 3 remaining Sprint B defects identified in the full QA audit. All changes are surgical — no existing functionality touched.

---

## Changes

### listUsers was silently filtering to customers only
**File:** `backend/src/controllers/userController.js`

The `listUsers` endpoint (admin only) had `.eq('role', 'customer')` hardcoded, meaning admins could never see provider accounts in the users list.

- Removed the hardcoded filter
- Added optional `?role=customer|provider|admin` query param so admins can still filter if needed
- Default (no param) now returns all users

---

### createReview had no customer role guard
**File:** `backend/src/routes/reviewRoutes.js`

`POST /api/reviews` only required `authenticate` but not `requireRole('customer')`. A provider JWT could technically call the review endpoint.

- Added `requireRole('customer')` between `authenticate` and `createReview` on the POST route
- Added `requireRole` to the import
- The controller-level booking ownership check (`customer_id === internalUser.id`) already acts as a practical guard — this makes the intent explicit at the route level

---

###  BookingModal showed fake fallback slots with no warning
**File:** `frontend/src/components/BookingModal.tsx`

When a provider has no availability slots set in the DB, `BookingModal` silently fell back to generated 9am–5pm hourly slots. Customers had no way to know these weren't real provider-defined windows.

- Added `usedFallback` boolean state
- State is set to `true` whenever `generateFallbackSlots()` is called (API returns empty or request errors)
- State resets to `false` when real slots are returned or when the selected date changes
- When `usedFallback` is `true`, an amber warning banner renders above the slot grid:
  *"Suggested times only — this provider hasn't set specific availability. These are general windows. The provider will confirm your chosen time after booking."*

---

## Test Results
- Backend Jest suite: **164 / 164 passing** (8 suites)
- Frontend TypeScript: **0 errors** (`npx tsc --noEmit`)
- No existing tests modified

## Checklist
- [x] Only files listed above were modified
- [x] No existing working functionality changed
- [x] All 164 regression tests pass
- [x] TypeScript compiles clean
- [x] Follows existing code style and commit conventions