### PR TITLE
hotfix: sprint 6 final QA fixes (6 cherry-pickable commits)

### DIFF
--- a/backend/src/controllers/complaintController.js
+++ b/backend/src/controllers/complaintController.js
@@ -1,6 +1,14 @@
 import supabase from '../config/supabase.js';
 import { getInternalUser, profileNotFoundResponse } from '../utils/internalUser.js';
 
+// Subjects accepted by the complaints_subject_check DB constraint. Keep this
+// in sync with the Postgres CHECK constraint on public.complaints.subject.
+export const ALLOWED_COMPLAINT_SUBJECTS = [
+  'Provider did not show up',
+  'Safety concern',
+  'Other',
+];
+
 // POST /api/complaints
 export const createComplaint = async (req, res) => {
   try {
@@ -8,6 +16,15 @@ export const createComplaint = async (req, res) => {
 
     if (!subject || !description) {
       return res.status(400).json({ success: false, error: 'subject and description are required' });
+    }
+
+    if (!ALLOWED_COMPLAINT_SUBJECTS.includes(subject)) {
+      return res.status(400).json({
+        success: false,
+        error: 'Invalid subject',
+        message: `Subject must be one of: ${ALLOWED_COMPLAINT_SUBJECTS.join(', ')}.`,
+        allowedSubjects: ALLOWED_COMPLAINT_SUBJECTS,
+      });
     }
 
     const internalUser = await getInternalUser(req.user.id);

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -76,8 +76,11 @@ export const getMe = async (req, res) => {
       dob = extras.dob ?? dob;
     }
 
-    // provider is the first element of the joined array (or null if no row yet)
-    const provider = user.providers?.[0] ?? null;
+    // Supabase returns the joined providers row as an object for to-one
+    // relations and as an array for to-many. Handle both shapes.
+    const provider = Array.isArray(user.providers)
+      ? (user.providers[0] ?? null)
+      : (user.providers ?? null);
 
     if (user.role === 'provider') {
       if (!provider) {

--- a/frontend/src/components/BookingModal.tsx
+++ b/frontend/src/components/BookingModal.tsx
@@ -499,6 +499,15 @@ export const BookingModal: React.FC<BookingModalProps> = ({
             </div>
           )}
 
+          {/* ── Validation hint ──────────────────────────────────────────── */}
+          {(!selectedDate || !selectedSlot) && (
+            <p className="text-xs text-slate-500 -mt-1">
+              {!selectedDate
+                ? "Pick a date to see available time slots."
+                : "Pick a time slot to confirm your booking."}
+            </p>
+          )}
+
           {/* ── Actions ────────────────────────────────────────────────────── */}
           <div className="flex gap-3 pb-1">
             <button

--- a/frontend/src/components/BookingModal.tsx
+++ b/frontend/src/components/BookingModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   X,
   Calendar,
@@ -122,6 +122,15 @@ export const BookingModal: React.FC<BookingModalProps> = ({
   const [error, setError] = useState<string | null>(null);
   // Tracks whether displayed slots are real provider slots or generated fallbacks
   const [usedFallback, setUsedFallback] = useState(false);
+  const errorRef = useRef<HTMLDivElement | null>(null);
+
+  // Scroll the error into view whenever it appears so users actually see
+  // backend rejections instead of staring at a "still nothing" modal.
+  useEffect(() => {
+    if (error && errorRef.current) {
+      errorRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [error]);
 
   useEffect(() => {
     const p = readDamagePrefill();
@@ -463,9 +472,14 @@ export const BookingModal: React.FC<BookingModalProps> = ({
 
           {/* ── Error ─────────────────────────────────────────────────────── */}
           {error && (
-            <div className="flex items-start gap-2 bg-red-50 border border-red-100 text-red-700 rounded-xl px-4 py-3 text-sm">
+            <div
+              ref={errorRef}
+              role="alert"
+              aria-live="assertive"
+              className="flex items-start gap-2 bg-red-50 border border-red-200 text-red-700 rounded-xl px-4 py-3 text-sm"
+            >
               <AlertCircle size={16} className="mt-0.5 flex-shrink-0" />
-              {error}
+              <span>{error}</span>
             </div>
           )}
 

--- a/frontend/src/components/ServiceCatalogModal.tsx
+++ b/frontend/src/components/ServiceCatalogModal.tsx
@@ -100,7 +100,8 @@ export const ServiceCatalogModal: React.FC<ServiceCatalogModalProps> = ({
     url.searchParams.set("category", categoryId);
     if (debouncedSearch) url.searchParams.set("search", debouncedSearch);
 
-    fetch(url.toString())
+    const controller = new AbortController();
+    fetch(url.toString(), { signal: controller.signal })
       .then((res) => res.json())
       .then((data) => {
         if (data.success && Array.isArray(data.data)) {
@@ -109,8 +110,13 @@ export const ServiceCatalogModal: React.FC<ServiceCatalogModalProps> = ({
           setError(true);
         }
       })
-      .catch(() => setError(true))
-      .finally(() => setLoading(false));
+      .catch((err) => {
+        if (err?.name !== "AbortError") setError(true);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
   }, [categoryId, debouncedSearch, API_BASE]);
 
   // Close on Escape key

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -37,15 +37,20 @@ export const Home: React.FC<HomeProps> = ({ onNavigate, user }) => {
   const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://localhost:3000";
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/categories`)
+    const controller = new AbortController();
+    fetch(`${API_BASE}/api/categories`, { signal: controller.signal })
       .then((res) => res.json())
       .then((json) => {
         const list = json?.data ?? json;
         if (Array.isArray(list)) setCategories(list);
       })
-      .catch(() => {
-        // Silently fail — categories still display, just no modal functionality
+      .catch((err) => {
+        // Ignore abort errors triggered by StrictMode / unmount; log others.
+        if (err?.name !== "AbortError") {
+          // Silently fail — categories still display, just no modal functionality
+        }
       });
+    return () => controller.abort();
   }, [API_BASE]);
 
   const handleCategoryClick = (displayName: string) => {

--- a/frontend/src/pages/ServiceProviders.tsx
+++ b/frontend/src/pages/ServiceProviders.tsx
@@ -188,25 +188,32 @@ export const ServiceProviders: React.FC<ServiceProvidersProps> = ({
 
   // Fetch aggregate reviews for this service (SER-82)
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     async function loadServiceReviews() {
       setServiceReviewsLoading(true);
       try {
-        const res = await fetch(`${API_BASE}/api/reviews/service/${serviceId}?limit=5`);
+        const res = await fetch(
+          `${API_BASE}/api/reviews/service/${serviceId}?limit=5`,
+          { signal: controller.signal },
+        );
         const data = await res.json();
-        if (cancelled || !data.success) return;
+        if (controller.signal.aborted || !data.success) return;
         const payload = data.data ?? {};
         setServiceReviews(Array.isArray(payload.reviews) ? payload.reviews : []);
         setServiceReviewsAvg(payload.avgRating ?? 0);
         setServiceReviewsCount(payload.count ?? 0);
-      } catch {
-        // non-fatal — section just won't render
+      } catch (err) {
+        // Swallow abort noise; other failures are non-fatal — section
+        // just won't render.
+        if ((err as { name?: string })?.name !== "AbortError") {
+          // intentionally silent
+        }
       } finally {
-        if (!cancelled) setServiceReviewsLoading(false);
+        if (!controller.signal.aborted) setServiceReviewsLoading(false);
       }
     }
     loadServiceReviews();
-    return () => { cancelled = true; };
+    return () => controller.abort();
   }, [serviceId, API_BASE]);
 
   const categorySlug = service?.categorySlug ?? "";


### PR DESCRIPTION
## Summary

Six independent hotfixes from the final QA pass, each in its own commit so any subset can be cherry-picked onto `main`. Rebased onto latest `main` after #108/#109/#110 merged — the BUG-01 (booking validator) and BUG-02 (availability route) fixes from the original branch are now redundant with #108 and the existing availability controller, so they were dropped.

| Commit | Bug | What it fixes |
|---|---|---|
| `fix(BUG-04)` | Provider profile_incomplete | userController treated providers join as array; Supabase returns it as an object for to-one. Accept both shapes. |
| `fix(BUG-08)` | Confirm Booking silent | Inline hint above the action row explaining whether date or slot is missing. |
| `fix(BUG-09)` | Booking errors swallowed | Error block now scrolls into view and uses role=alert / aria-live=assertive so 400s from /api/bookings are visible. |
| `fix(BUG-11)` | Complaint subject leak | Validate against the 3 allowed subjects up-front; return structured 400 with allowedSubjects instead of raw DB constraint name. |
| `fix(BUG-14)` | StrictMode double-fetch | AbortController on Home and ServiceCatalogModal fetches. |
| `fix(BUG-15)` | Aborted GETs on nav | AbortController on ServiceProviders aggregate-reviews fetch. |

## Test plan

- [x] BUG-04 — GET /api/users/me as deep_plumber returns business_name="Deep Plumber Services", profile_incomplete=false
- [x] BUG-08 — Open booking modal with no selection → "Pick a date to see available time slots." renders
- [x] BUG-09 — error block has ref + scrollIntoView + role=alert + aria-live wired
- [x] BUG-11 — POST /api/complaints with subject="Quality issue" returns 400 with allowedSubjects=["Provider did not show up","Safety concern","Other"]
- [x] BUG-14 — AbortController.abort() on Home + ServiceCatalogModal cleanup
- [x] BUG-15 — AbortController.abort() on ServiceProviders reviews effect cleanup

## Notes

- BUG-01 and BUG-02 from the original report were already addressed on `main` via #108 and the existing availability controller, so those commits were dropped during rebase.
- BUG-10 dropped — false positive. UI never sends POST /api/chatbot; chatbot was always client-side and now uses Groq via #109.
- Other QA findings (junk seed row, stale 2024 footer, missing customer-cancel route, profile validator regex, complaint enum docs) are out of scope for this hotfix.