### PR TITLE
feat: auto-complete past confirmed bookings (cron workaround)

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -8,6 +8,7 @@ import rateLimit from 'express-rate-limit';
 import { checkSupabaseConnection } from './config/supabase.js';
 import { validateVdaServiceConfig, validateVdaAuthConfig } from './config/vdaServiceConfig.js';
 import { startReminderCron } from './services/reminderService.js';
+import { startAutoCompleteCron } from './services/autoCompleteService.js';
 import categoryRoutes from './routes/categoryRoutes.js';
 import serviceRoutes from './routes/serviceRoutes.js';
 import profileRoutes from './routes/profileRoutes.js';
@@ -33,6 +34,7 @@ if (process.env.NODE_ENV !== 'test') {
   validateVdaServiceConfig();
   validateVdaAuthConfig();
   startReminderCron();
+  startAutoCompleteCron();
 }
 
 // ── Rate limiters ─────────────────────────────────────────────────────────

--- a/backend/src/services/autoCompleteService.js
+++ b/backend/src/services/autoCompleteService.js
@@ -1,0 +1,49 @@
+import cron from 'node-cron';
+import supabase from '../config/supabase.js';
+
+/**
+ * Marks confirmed bookings whose scheduled_at is in the past as completed.
+ *
+ * Workaround for the missing customer-side / automated complete flow: until a
+ * proper completion handshake exists, any confirmed booking past its
+ * scheduled_at is treated as fulfilled. Pending and cancelled bookings are
+ * left alone.
+ *
+ * Idempotent — the .eq('status', 'confirmed') guard means re-runs are no-ops
+ * once a row has been flipped, and races with provider-side completeBooking
+ * resolve safely (whichever lands second updates zero rows).
+ */
+export async function autoCompletePastBookings() {
+  const nowIso = new Date().toISOString();
+
+  const { data: updated, error } = await supabase
+    .from('bookings')
+    .update({ status: 'completed', completed_at: nowIso })
+    .eq('status', 'confirmed')
+    .lt('scheduled_at', nowIso)
+    .select('id');
+
+  if (error) {
+    console.error('❌ Auto-complete query error:', error.message);
+    return { completed: 0, errors: 1 };
+  }
+
+  const count = updated?.length ?? 0;
+  if (count > 0) {
+    console.log(`✅ Auto-completed ${count} past booking(s) at ${nowIso}`);
+  }
+  return { completed: count, errors: 0 };
+}
+
+/**
+ * Starts the auto-complete cron. Call once on server startup (skipped in tests).
+ * Same 15-minute cadence as the reminder cron so the load profile stays similar.
+ */
+export function startAutoCompleteCron() {
+  cron.schedule('*/15 * * * *', () => {
+    autoCompletePastBookings().catch((err) =>
+      console.error('❌ Auto-complete cron unhandled error:', err),
+    );
+  });
+  console.log('🕒 Booking auto-complete cron started (runs every 15 min)');
+}


### PR DESCRIPTION
## Summary

Workaround for the missing customer-side / automated booking-completion flow. A small cron job runs every 15 minutes and flips any \`confirmed\` booking whose \`scheduled_at\` has passed to \`completed\` with \`completed_at = now()\`. \`pending\` and \`cancelled\` bookings are not touched.

## Why a cron, not a lazy check

- Stats and dashboards (provider earnings, customer history) read \`status\` directly. A lazy check at read time would require touching every read path.
- Reviews are gated on \`status='completed'\` — a periodic flip makes them eligible automatically.
- Same 15-minute cadence as the existing reminder cron, so the load profile is unchanged.

## Dependencies considered

- **Race with provider \`completeBooking\`**: \`.eq('status','confirmed')\` makes the update idempotent — whichever lands second updates zero rows.
- **Email notifications**: the manual completeBooking handler does not send a completion email today, so no email behavior change.
- **Reviews**: customers can now review bookings whose date has passed, which is the desired side-effect.
- **Stats**: provider/customer dashboards aggregate by status; auto-completed rows roll into the \"completed\" bucket the next time the dashboard loads.

## Test plan

- [x] \`autoCompletePastBookings()\` flips 2 real seeded confirmed-but-past bookings to \`completed\` with \`completed_at\` populated.
- [x] Second run is a no-op (\`{completed: 0, errors: 0}\`) — idempotent.
- [x] Server boot logs \`🕒 Booking auto-complete cron started (runs every 15 min)\`.

## Out of scope

- Building a real provider/customer completion handshake (e.g. customer-confirms-finished).
- Sending a "your appointment is now complete" email.