### PR TITLE
fix(verification): Bug-Fix-3 - identity verification pipeline overhaul

### DIFF
--- a/ai-services/app/routes/nsopw_routes.py
+++ b/ai-services/app/routes/nsopw_routes.py
@@ -27,6 +27,7 @@ class NsopwCheckBody(BaseModel):
     lastName: str = Field(..., min_length=1, description="Provider's last name")
     state: Optional[str] = Field(None, description="Two-letter state code, e.g. NJ")
     zipCode: Optional[str] = Field(None, description="Five-digit ZIP code from ID document")
+    city: Optional[str] = Field(None, description="City name — used for Chicago jurisdiction routing")
 
 
 # ── Internal API key guard ────────────────────────────────────────────────
@@ -68,5 +69,6 @@ async def check_nsopw(
         last_name=body.lastName,
         state=body.state,
         zip_code=body.zipCode,
+        city=body.city,
     )
     return result

--- a/ai-services/app/services/nsopw_service.py
+++ b/ai-services/app/services/nsopw_service.py
@@ -66,6 +66,129 @@ INTERSTITIAL_MARKERS = (
 )
 
 
+# ── Jurisdiction-specific REST helpers ───────────────────────────────────
+
+async def _check_iowa(first_name: str, last_name: str) -> Dict[str, Any]:
+    """Iowa Sex Offender Registry — GET JSON API (50 req/hr cap)."""
+    url = "https://www.iowasexoffender.gov/api/search/results.json"
+    params = {"lastname": last_name, "firstname": first_name}
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    records = data if isinstance(data, list) else data.get("results", [])
+    match_found = len(records) > 0
+    return {
+        "nsopwStatus": "fail" if match_found else "pass",
+        "matchFound": match_found,
+        "matchDetails": [{"name": r.get("name", "")} for r in records[:5]],
+        "checkedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "iowasexoffender.gov",
+    }
+
+
+async def _check_missouri(first_name: str, last_name: str) -> Dict[str, Any]:
+    """Missouri MSHP Sex Offender Registry — ArcGIS REST query."""
+    url = (
+        "https://www.mshp.dps.missouri.gov/arcgis/rest/services"
+        "/NSOR/MapServer/7/query"
+    )
+    where = (
+        f"LAST_NAME='{last_name.upper()}' AND FIRST_NAME='{first_name.upper()}'"
+    )
+    params = {
+        "where": where,
+        "outFields": "FIRST_NAME,LAST_NAME,CITY",
+        "f": "json",
+        "resultRecordCount": 10,
+    }
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    features = data.get("features", [])
+    match_found = len(features) > 0
+    return {
+        "nsopwStatus": "fail" if match_found else "pass",
+        "matchFound": match_found,
+        "matchDetails": [
+            {
+                "name": (
+                    f"{f['attributes'].get('FIRST_NAME', '')} "
+                    f"{f['attributes'].get('LAST_NAME', '')}".strip()
+                )
+            }
+            for f in features[:5]
+        ],
+        "checkedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "mshp.dps.missouri.gov",
+    }
+
+
+async def _check_dc(first_name: str, last_name: str) -> Dict[str, Any]:
+    """Washington D.C. Sex Offender Registry — DC GIS FeatureServer query."""
+    url = (
+        "https://maps2.dcgis.dc.gov/dcgis/rest/services"
+        "/FEEDS/MPD/FeatureServer/20/query"
+    )
+    where = (
+        f"LASTNAME='{last_name.upper()}' AND FIRSTNAME='{first_name.upper()}'"
+    )
+    params = {
+        "where": where,
+        "outFields": "*",
+        "f": "json",
+        "resultRecordCount": 10,
+    }
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    features = data.get("features", [])
+    match_found = len(features) > 0
+    return {
+        "nsopwStatus": "fail" if match_found else "pass",
+        "matchFound": match_found,
+        "matchDetails": [
+            {
+                "name": (
+                    f"{f['attributes'].get('FIRSTNAME', '')} "
+                    f"{f['attributes'].get('LASTNAME', '')}".strip()
+                )
+            }
+            for f in features[:5]
+        ],
+        "checkedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "maps2.dcgis.dc.gov",
+    }
+
+
+async def _check_chicago(first_name: str, last_name: str) -> Dict[str, Any]:
+    """Chicago Sex Offender Registry — Socrata open data API."""
+    url = "https://data.cityofchicago.org/resource/vc9r-bqvy.json"
+    params = {"LASTNAME": last_name.upper(), "FIRSTNAME": first_name.upper()}
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        records = resp.json()
+    match_found = len(records) > 0
+    return {
+        "nsopwStatus": "fail" if match_found else "pass",
+        "matchFound": match_found,
+        "matchDetails": [
+            {
+                "name": (
+                    f"{r.get('FIRSTNAME', '')} "
+                    f"{r.get('LASTNAME', '')}".strip()
+                )
+            }
+            for r in records[:5]
+        ],
+        "checkedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "data.cityofchicago.org",
+    }
+
+
 # ── Public API ────────────────────────────────────────────────────────────
 
 async def check_nsopw(
@@ -73,12 +196,14 @@ async def check_nsopw(
     last_name: str,
     state: Optional[str] = None,
     zip_code: Optional[str] = None,
+    city: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
-    Search NSOPW for a provider and check if their name appears in results.
+    Search for a provider in sex offender registries.
 
-    Uses Playwright (ZIP code search) as the primary strategy. Falls back
-    to httpx scraping (first/last name) if Playwright is unavailable.
+    Routes to a jurisdiction-specific REST API when the state/city is one of
+    the four supported jurisdictions (IA, MO, DC, Chicago/IL).  Falls back to
+    the NSOPW Playwright scraper for all other jurisdictions.
 
     PII is NEVER passed to any logger call.
 
@@ -87,6 +212,7 @@ async def check_nsopw(
         last_name:  Provider's legal last name.
         state:      Optional two-letter state code (e.g. "NJ").
         zip_code:   Optional five-digit ZIP code from their ID document.
+        city:       Optional city name — used for Chicago jurisdiction routing.
 
     Returns:
         dict with nsopwStatus, matchFound, matchDetails, checkedAt, source.
@@ -102,6 +228,26 @@ async def check_nsopw(
         "checkedAt": checked_at,
         "source": "nsopw.gov",
     }
+
+    # ── Jurisdiction routing (REST APIs — no browser, faster) ────────────
+    state_upper = (state or "").upper()
+    city_upper = (city or "").upper()
+    try:
+        if state_upper == "IA":
+            return await _check_iowa(first_name, last_name)
+        if state_upper == "MO":
+            return await _check_missouri(first_name, last_name)
+        if state_upper == "DC":
+            return await _check_dc(first_name, last_name)
+        if state_upper == "IL" and city_upper == "CHICAGO":
+            return await _check_chicago(first_name, last_name)
+    except Exception as exc:
+        logger.error(
+            "Jurisdiction REST API failed (%s) — %s: falling back to NSOPW",
+            state_upper,
+            type(exc).__name__,
+        )
+        # Fall through to NSOPW Playwright scraper below.
 
     # ── Strategy 1: Playwright + ZIP Code ─────────────────────────────────
     if zip_code:

--- a/ai-services/app/services/ocr_service.py
+++ b/ai-services/app/services/ocr_service.py
@@ -454,19 +454,43 @@ def _parse_drivers_license(raw_text: str) -> Dict[str, Optional[str]]:
         result["address"] = addr.group(0).strip()
 
     # ── License / DL number ───────────────────────────────────────────────
+    _dl_skip = frozenset({
+        "CLASS", "DONOR", "EYES", "HAIR", "SEX", "NONE", "REAL", "HAZMAT",
+    })
     dl_patterns = [
-        r"(?:DL|DLN|ID|LIC|LICENSE|LICENCE)\s*(?:NO|NUMBER|NUM|#)?[:\s#]*([A-Z0-9]{4,15})",
-        r"(?:^|\n)\s*(?:NO|NUM|NUMBER)[:\s]+([A-Z0-9]{6,15})",
-        r"\b([A-Z]\d{7,14})\b",  # Common format: letter + digits
+        # Same-line labeled: "DL A123456" / "DLN: A123456" / "LICENSE NO A123456"
+        # [: \t#]+ intentionally excludes newlines to avoid grabbing the wrong line
+        r"(?:DLN?|LIC(?:ENSE|ENCE)?(?:\s*(?:NO\.?|NUM(?:BER)?|#))?)\s*[: \t#]+([A-Z]{0,2}[A-Z0-9]{5,14})",
+        # "ID NO:" / "ID #" — require explicit qualifier to avoid false matches on "IDENTIFICATION"
+        r"ID\s*(?:NO\.?|NUM(?:BER)?|#)\s*[: \t#]*([A-Z]{0,2}[A-Z0-9]{5,14})",
+        # Label on one line, number on the next: "DL\nA1234567"
+        r"(?:DLN?|LIC(?:ENSE|ENCE)?)\b[^\n]*\n[ \t]*([A-Z]{0,2}[A-Z0-9]{5,14})",
+        # "NO" / "NUMBER" at line start
+        r"(?:^|\n)[ \t]*(?:NO\.?|NUM(?:BER)?)[: \t]+([A-Z]{0,2}[A-Z0-9]{5,14})",
+        # Structural: 1 letter + 7-14 digits (CA A1234567, FL A123456789012, MD, GA, IL, VA)
+        r"\b([A-Z][0-9]{7,14})\b",
+        # Structural: 2 letters + 5-9 digits (PA AA123456, WA, NV)
+        r"\b([A-Z]{2}[0-9]{5,9})\b",
+        # Structural: 9-14 consecutive digits (NY=9, NJ=14, CO=9, MA=9, MN=13)
+        r"\b([0-9]{9,14})\b",
     ]
     for pattern in dl_patterns:
         id_num = re.search(pattern, raw_text, re.IGNORECASE)
         if id_num:
-            val = id_num.group(1).upper()
-            # Skip too-short values or things that look like dates
-            if len(val) >= 5 and not re.match(r"^\d{1,2}\d{1,2}\d{2,4}$", val):
-                result["document_number"] = val
-                break
+            val = id_num.group(1).upper().strip()
+            if len(val) < 5:
+                continue
+            if val in _dl_skip:
+                continue
+            # Reject 8-digit strings that are valid compressed dates (MMDDYYYY)
+            if len(val) == 8 and val.isdigit():
+                try:
+                    if 1 <= int(val[:2]) <= 12 and 1 <= int(val[2:4]) <= 31:
+                        continue
+                except ValueError:
+                    pass
+            result["document_number"] = val
+            break
 
     # ── Issuing state ─────────────────────────────────────────────────────
     US_STATES = {

--- a/ai-services/tests/test_registry_routing.py
+++ b/ai-services/tests/test_registry_routing.py
@@ -1,0 +1,123 @@
+"""
+test_registry_routing.py — REG-01 through REG-06
+Jurisdiction routing in check_nsopw: each supported state/city routes to the
+correct REST helper, and a helper failure falls back to the NSOPW httpx scraper.
+"""
+
+import pytest
+from unittest.mock import patch, AsyncMock
+
+from app.services.nsopw_service import check_nsopw
+
+# ── Shared stubs ─────────────────────────────────────────────────────────
+
+_PASS = {
+    "nsopwStatus": "pass",
+    "matchFound": False,
+    "matchDetails": [],
+    "checkedAt": "2024-01-01T00:00:00+00:00",
+    "source": "stub",
+}
+
+_NSOPW_FALLBACK = {
+    "nsopwStatus": "pass",
+    "matchFound": False,
+    "matchDetails": [],
+    "checkedAt": "2024-01-01T00:00:00+00:00",
+    "source": "nsopw.gov",
+}
+
+
+# ── REG-01: Iowa ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_reg01_iowa_routes_to_check_iowa():
+    """REG-01: state=IA calls _check_iowa instead of the NSOPW scraper."""
+    with patch(
+        "app.services.nsopw_service._check_iowa",
+        new=AsyncMock(return_value=_PASS),
+    ) as mock_iowa:
+        result = await check_nsopw("John", "Doe", state="IA")
+
+    mock_iowa.assert_called_once_with("John", "Doe")
+    assert result["source"] == "stub"
+
+
+# ── REG-02: Missouri ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_reg02_missouri_routes_to_check_missouri():
+    """REG-02: state=MO calls _check_missouri instead of the NSOPW scraper."""
+    with patch(
+        "app.services.nsopw_service._check_missouri",
+        new=AsyncMock(return_value=_PASS),
+    ) as mock_mo:
+        result = await check_nsopw("Jane", "Smith", state="MO")
+
+    mock_mo.assert_called_once_with("Jane", "Smith")
+    assert result["source"] == "stub"
+
+
+# ── REG-03: Washington DC ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_reg03_dc_routes_to_check_dc():
+    """REG-03: state=DC calls _check_dc instead of the NSOPW scraper."""
+    with patch(
+        "app.services.nsopw_service._check_dc",
+        new=AsyncMock(return_value=_PASS),
+    ) as mock_dc:
+        result = await check_nsopw("Alice", "Jones", state="DC")
+
+    mock_dc.assert_called_once_with("Alice", "Jones")
+    assert result["source"] == "stub"
+
+
+# ── REG-04: Chicago ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_reg04_chicago_routes_to_check_chicago():
+    """REG-04: state=IL + city=Chicago calls _check_chicago."""
+    with patch(
+        "app.services.nsopw_service._check_chicago",
+        new=AsyncMock(return_value=_PASS),
+    ) as mock_chi:
+        result = await check_nsopw("Bob", "Williams", state="IL", city="Chicago")
+
+    mock_chi.assert_called_once_with("Bob", "Williams")
+    assert result["source"] == "stub"
+
+
+# ── REG-05: Illinois (non-Chicago) skips _check_chicago ──────────────────
+
+@pytest.mark.asyncio
+async def test_reg05_illinois_non_chicago_does_not_call_check_chicago():
+    """REG-05: state=IL + city!=Chicago must NOT call _check_chicago; falls back to httpx."""
+    with patch(
+        "app.services.nsopw_service._check_chicago"
+    ) as mock_chi, patch(
+        "app.services.nsopw_service._httpx_search",
+        new=AsyncMock(return_value=_NSOPW_FALLBACK),
+    ):
+        result = await check_nsopw("Carol", "Brown", state="IL", city="Springfield")
+
+    mock_chi.assert_not_called()
+    assert result["nsopwStatus"] == "pass"
+
+
+# ── REG-06: REST helper failure triggers NSOPW fallback ──────────────────
+
+@pytest.mark.asyncio
+async def test_reg06_rest_failure_falls_back_to_nsopw_httpx():
+    """REG-06: When _check_iowa raises, check_nsopw falls back to the httpx scraper."""
+    with patch(
+        "app.services.nsopw_service._check_iowa",
+        new=AsyncMock(side_effect=RuntimeError("API down")),
+    ), patch(
+        "app.services.nsopw_service._httpx_search",
+        new=AsyncMock(return_value=_NSOPW_FALLBACK),
+    ) as mock_httpx:
+        result = await check_nsopw("John", "Doe", state="IA")
+
+    mock_httpx.assert_called_once()
+    assert result["source"] == "nsopw.gov"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3231,12 +3231,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3941,9 +3941,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/backend/src/controllers/verificationController.js
+++ b/backend/src/controllers/verificationController.js
@@ -59,7 +59,7 @@ export const getPrefill = async (req, res) => {
 
     const { data: user, error } = await supabase
       .from('users')
-      .select('full_name, email, phone')
+      .select('full_name, email, phone, dob')
       .eq('id', internalUser.id)
       .single();
 
@@ -74,7 +74,7 @@ export const getPrefill = async (req, res) => {
         full_name: user.full_name,
         email: user.email,
         phone: user.phone || null,
-        date_of_birth: null,
+        date_of_birth: user.dob || null,
       },
       error: null,
     });
@@ -213,7 +213,7 @@ export const uploadId = async (req, res) => {
     });
   } catch (err) {
     console.error('uploadId error:', err);
-    return res.status(500).json({ success: false, data: null, error: err.stack || err.message || 'Failed to process ID document' });
+    return res.status(500).json({ success: false, data: null, error: 'Failed to process ID document. Please try again.' });
   }
 };
 

--- a/backend/src/controllers/verificationController.js
+++ b/backend/src/controllers/verificationController.js
@@ -25,11 +25,27 @@ const AI_INTERNAL_KEY = process.env.AI_INTERNAL_API_KEY || 'change-me-in-product
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
+/**
+ * Normalize a raw DOB string to YYYY-MM-DD.
+ * Handles: YYYY-MM-DD (passthrough), MM/DD/YYYY, MM-DD-YYYY.
+ * Returns null when the format is unrecognised.
+ */
+const normalizeDob = (raw) => {
+  if (!raw) return null;
+  const s = raw.trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
+  const slash = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (slash) return `${slash[3]}-${slash[1].padStart(2, '0')}-${slash[2].padStart(2, '0')}`;
+  const dash = s.match(/^(\d{1,2})-(\d{1,2})-(\d{4})$/);
+  if (dash) return `${dash[3]}-${dash[1].padStart(2, '0')}-${dash[2].padStart(2, '0')}`;
+  return null;
+};
+
 /** Resolve Supabase auth id → internal public.users row */
 const getInternalUser = async (supabaseId) => {
   const { data, error } = await supabase
     .from('users')
-    .select('id, full_name, email, phone, role')
+    .select('id, full_name, email, phone, dob, role')
     .eq('supabase_id', supabaseId)
     .single();
   if (error) return null;
@@ -57,24 +73,14 @@ export const getPrefill = async (req, res) => {
       return res.status(404).json({ success: false, data: null, error: 'User not found' });
     }
 
-    const { data: user, error } = await supabase
-      .from('users')
-      .select('full_name, email, phone, dob')
-      .eq('id', internalUser.id)
-      .single();
-
-    if (error || !user) {
-      return res.status(404).json({ success: false, data: null, error: 'User not found' });
-    }
-
     // Only return safe, non-sensitive fields — never password, tokens, supabase_id
     return res.json({
       success: true,
       data: {
-        full_name: user.full_name,
-        email: user.email,
-        phone: user.phone || null,
-        date_of_birth: user.dob || null,
+        full_name: internalUser.full_name,
+        email: internalUser.email,
+        phone: internalUser.phone || null,
+        date_of_birth: internalUser.dob || null,
       },
       error: null,
     });
@@ -162,7 +168,10 @@ export const uploadId = async (req, res) => {
     const extractedName = ocrResult?.extractedName || ocrResult?.extracted_data?.full_name || null;
     const extractedDob = ocrResult?.extractedDOB || ocrResult?.extracted_data?.date_of_birth || null;
 
-    // Save verification record — find existing or create new
+    // Always insert a new record per attempt — never overwrite previous attempts.
+    // uploadSelfie and submitVerification find the latest record via
+    // .order('created_at', { ascending: false }).limit(1) so they naturally
+    // pick up this new row.
     const verificationPayload = {
       document_type: documentType,
       id_document_url: uploadResult.path,
@@ -173,31 +182,27 @@ export const uploadId = async (req, res) => {
       updated_at: new Date().toISOString(),
     };
 
-    // Check if a verification record already exists for this user
-    const { data: existing } = await supabase
+    const { error: insertError } = await supabase
       .from('verifications')
-      .select('id')
-      .eq('user_id', internalUser.id)
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
+      .insert({ user_id: internalUser.id, ...verificationPayload });
+    if (insertError) {
+      console.error('Verification insert error:', insertError.message);
+    }
 
-    if (existing) {
-      // Update the existing record
-      const { error: updateError } = await supabase
-        .from('verifications')
-        .update(verificationPayload)
-        .eq('id', existing.id);
-      if (updateError) {
-        console.error('Verification update error:', updateError.message);
-      }
-    } else {
-      // Insert a new record
-      const { error: insertError } = await supabase
-        .from('verifications')
-        .insert({ user_id: internalUser.id, ...verificationPayload });
-      if (insertError) {
-        console.error('Verification insert error:', insertError.message);
+    // DOB mismatch check — if OCR found a DOB that differs from the profile, auto-update.
+    let dobMismatch = false;
+    if (extractedDob) {
+      const ocrNorm = normalizeDob(extractedDob) ?? extractedDob;
+      const dbNorm = normalizeDob(internalUser.dob) ?? internalUser.dob ?? null;
+      if (ocrNorm !== dbNorm) {
+        dobMismatch = true;
+        const { error: dobUpdateErr } = await supabase
+          .from('users')
+          .update({ dob: ocrNorm })
+          .eq('id', internalUser.id);
+        if (dobUpdateErr) {
+          console.error('DOB update error:', dobUpdateErr.message);
+        }
       }
     }
 
@@ -208,6 +213,7 @@ export const uploadId = async (req, res) => {
         extractedName,
         extractedDob,
         documentPath: uploadResult.path,
+        dobMismatch,
       },
       error: null,
     });
@@ -321,7 +327,7 @@ export const uploadSelfie = async (req, res) => {
       .update({
         selfie_url: uploadResult.path,
         face_match_result: faceMatchResult,
-        face_match_score: faceMatchResult?.similarity_score || 0.0,
+        face_match_score: faceMatchResult?.similarity ?? 0.0,
         updated_at: new Date().toISOString(),
       })
       .eq('id', verification.id);
@@ -336,7 +342,7 @@ export const uploadSelfie = async (req, res) => {
     });
   } catch (err) {
     console.error('uploadSelfie error:', err);
-    return res.status(500).json({ success: false, data: null, error: err.stack || err.message || 'Failed to process selfie' });
+    return res.status(500).json({ success: false, data: null, error: 'Failed to process selfie image. Please try again.' });
   }
 };
 
@@ -420,13 +426,20 @@ export const submitVerification = async (req, res) => {
       }
     }
 
-    // ── Step 4b: Extract ZIP code from OCR address for NSOPW search ─────
+    // ── Step 4b: Extract ZIP code and city from OCR address ─────────────
     let zipCode = null;
+    let city = null;
     const ocrAddress = ocrResult.address || ocrResult.extracted_data?.address || '';
     if (typeof ocrAddress === 'string') {
       const zipMatch = ocrAddress.match(/\b(\d{5})(?:-\d{4})?\b/);
       if (zipMatch) {
         zipCode = zipMatch[1];
+      }
+      // City sits between the last comma-separated street segment and the state code
+      // e.g. "123 Main St, Chicago, IL 60601"
+      const cityMatch = ocrAddress.match(/,\s*([A-Za-z\s]+),\s*[A-Z]{2}/);
+      if (cityMatch) {
+        city = cityMatch[1].trim();
       }
     }
 
@@ -448,6 +461,7 @@ export const submitVerification = async (req, res) => {
           lastName,
           state,
           zipCode,
+          city,
         }),
         signal: controller.signal,
       });

--- a/backend/src/tests/verificationPrefill.test.js
+++ b/backend/src/tests/verificationPrefill.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for Bug-Fix-3:
+ *   VER-PREFILL-01/02 — getPrefill must return date_of_birth from users.dob (Bug A)
+ *   VER-UPLOAD-01     — uploadId 500 must not leak stack traces (Bug B-B2)
+ */
+
+import { jest } from '@jest/globals';
+
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-key';
+process.env.AI_SERVICES_URL = 'http://localhost:8000';
+process.env.AI_INTERNAL_API_KEY = 'test-key';
+
+let supabaseMock;
+
+jest.unstable_mockModule('../config/supabase.js', () => {
+  supabaseMock = { from: jest.fn() };
+  return { default: supabaseMock };
+});
+
+jest.unstable_mockModule('../services/supabaseVerificationStorage.js', () => ({
+  uploadVerificationDocument: jest.fn(),
+  generateVerificationPath: jest.fn().mockReturnValue('test/path.jpg'),
+  getSignedUrl: jest.fn(),
+}));
+
+const { getPrefill, uploadId } = await import('../controllers/verificationController.js');
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const makeChain = (resolveWith) => ({
+  select: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  upsert: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  maybeSingle: jest.fn().mockResolvedValue(resolveWith),
+  single: jest.fn().mockResolvedValue(resolveWith),
+});
+
+describe('getPrefill — Bug A (DOB)', () => {
+  test('VER-PREFILL-01: returns date_of_birth when users.dob is set', async () => {
+    const internalChain = makeChain({
+      data: { id: 'uuid-1', full_name: 'Jane Doe', email: 'jane@test.com', phone: '555-0001', role: 'provider' },
+      error: null,
+    });
+    const prefillChain = makeChain({
+      data: { full_name: 'Jane Doe', email: 'jane@test.com', phone: '555-0001', dob: '1990-03-15' },
+      error: null,
+    });
+
+    supabaseMock.from = jest.fn()
+      .mockReturnValueOnce(internalChain)
+      .mockReturnValueOnce(prefillChain);
+
+    const res = mockRes();
+    await getPrefill({ user: { id: 'supabase-uid' } }, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ date_of_birth: '1990-03-15' }),
+      })
+    );
+  });
+
+  test('VER-PREFILL-02: returns null date_of_birth when dob is null in DB', async () => {
+    const internalChain = makeChain({
+      data: { id: 'uuid-2', full_name: 'Bob', email: 'bob@test.com', phone: null, role: 'provider' },
+      error: null,
+    });
+    const prefillChain = makeChain({
+      data: { full_name: 'Bob', email: 'bob@test.com', phone: null, dob: null },
+      error: null,
+    });
+
+    supabaseMock.from = jest.fn()
+      .mockReturnValueOnce(internalChain)
+      .mockReturnValueOnce(prefillChain);
+
+    const res = mockRes();
+    await getPrefill({ user: { id: 'supabase-uid-2' } }, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({ date_of_birth: null }),
+      })
+    );
+  });
+});
+
+describe('uploadId — Bug B-B2 (no stack trace leak)', () => {
+  test('VER-UPLOAD-01: 500 body does not contain stack trace or raw error message', async () => {
+    const dbErr = new Error('DB connection failed');
+    dbErr.stack = 'Error: DB connection failed\n    at Object.<anonymous> (verificationController.js:30)';
+    supabaseMock.from = jest.fn().mockImplementation(() => { throw dbErr; });
+
+    const req = {
+      user: { id: 'supabase-uid' },
+      file: { mimetype: 'image/jpeg', size: 1000, buffer: Buffer.from('x'), originalname: 'id.jpg' },
+      body: { documentType: 'drivers_license' },
+    };
+    const res = mockRes();
+    await uploadId(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    const body = res.json.mock.calls[0][0];
+    const serialised = JSON.stringify(body);
+    expect(serialised).not.toMatch(/at Object\./);
+    expect(serialised).not.toMatch(/DB connection failed/);
+    expect(body.error).toBe('Failed to process ID document. Please try again.');
+  });
+});

--- a/backend/src/tests/verificationPrefill.test.js
+++ b/backend/src/tests/verificationPrefill.test.js
@@ -2,6 +2,9 @@
  * Tests for Bug-Fix-3:
  *   VER-PREFILL-01/02 — getPrefill must return date_of_birth from users.dob (Bug A)
  *   VER-UPLOAD-01     — uploadId 500 must not leak stack traces (Bug B-B2)
+ *   VER-INSERT-01     — uploadId always INSERTs a new row, never UPSERTs
+ *   VER-SELFIE-01     — uploadSelfie stores face_match_score from faceMatchResult.similarity
+ *   VER-SELFIE-02     — uploadSelfie 500 body does not contain stack trace
  */
 
 import { jest } from '@jest/globals';
@@ -24,7 +27,8 @@ jest.unstable_mockModule('../services/supabaseVerificationStorage.js', () => ({
   getSignedUrl: jest.fn(),
 }));
 
-const { getPrefill, uploadId } = await import('../controllers/verificationController.js');
+const { getPrefill, uploadId, uploadSelfie } = await import('../controllers/verificationController.js');
+const storageMock = await import('../services/supabaseVerificationStorage.js');
 
 const mockRes = () => {
   const res = {};
@@ -33,6 +37,8 @@ const mockRes = () => {
   return res;
 };
 
+// Chain factory: select/eq/order/limit all chain; single/maybeSingle are terminal promises.
+// insert/update/upsert chain (not terminal) — use dedicated chain objects when terminal behavior is needed.
 const makeChain = (resolveWith) => ({
   select: jest.fn().mockReturnThis(),
   eq: jest.fn().mockReturnThis(),
@@ -45,20 +51,17 @@ const makeChain = (resolveWith) => ({
   single: jest.fn().mockResolvedValue(resolveWith),
 });
 
+// ── VER-PREFILL-01/02 ────────────────────────────────────────────────────
+
 describe('getPrefill — Bug A (DOB)', () => {
   test('VER-PREFILL-01: returns date_of_birth when users.dob is set', async () => {
+    // getPrefill makes exactly ONE Supabase call (getInternalUser) after Bug A fix.
     const internalChain = makeChain({
-      data: { id: 'uuid-1', full_name: 'Jane Doe', email: 'jane@test.com', phone: '555-0001', role: 'provider' },
-      error: null,
-    });
-    const prefillChain = makeChain({
-      data: { full_name: 'Jane Doe', email: 'jane@test.com', phone: '555-0001', dob: '1990-03-15' },
+      data: { id: 'uuid-1', full_name: 'Jane Doe', email: 'jane@test.com', phone: '555-0001', dob: '1990-03-15', role: 'provider' },
       error: null,
     });
 
-    supabaseMock.from = jest.fn()
-      .mockReturnValueOnce(internalChain)
-      .mockReturnValueOnce(prefillChain);
+    supabaseMock.from = jest.fn().mockReturnValueOnce(internalChain);
 
     const res = mockRes();
     await getPrefill({ user: { id: 'supabase-uid' } }, res);
@@ -73,17 +76,11 @@ describe('getPrefill — Bug A (DOB)', () => {
 
   test('VER-PREFILL-02: returns null date_of_birth when dob is null in DB', async () => {
     const internalChain = makeChain({
-      data: { id: 'uuid-2', full_name: 'Bob', email: 'bob@test.com', phone: null, role: 'provider' },
-      error: null,
-    });
-    const prefillChain = makeChain({
-      data: { full_name: 'Bob', email: 'bob@test.com', phone: null, dob: null },
+      data: { id: 'uuid-2', full_name: 'Bob', email: 'bob@test.com', phone: null, dob: null, role: 'provider' },
       error: null,
     });
 
-    supabaseMock.from = jest.fn()
-      .mockReturnValueOnce(internalChain)
-      .mockReturnValueOnce(prefillChain);
+    supabaseMock.from = jest.fn().mockReturnValueOnce(internalChain);
 
     const res = mockRes();
     await getPrefill({ user: { id: 'supabase-uid-2' } }, res);
@@ -96,6 +93,8 @@ describe('getPrefill — Bug A (DOB)', () => {
     );
   });
 });
+
+// ── VER-UPLOAD-01 ────────────────────────────────────────────────────────
 
 describe('uploadId — Bug B-B2 (no stack trace leak)', () => {
   test('VER-UPLOAD-01: 500 body does not contain stack trace or raw error message', async () => {
@@ -117,5 +116,117 @@ describe('uploadId — Bug B-B2 (no stack trace leak)', () => {
     expect(serialised).not.toMatch(/at Object\./);
     expect(serialised).not.toMatch(/DB connection failed/);
     expect(body.error).toBe('Failed to process ID document. Please try again.');
+  });
+});
+
+// ── VER-INSERT-01 ────────────────────────────────────────────────────────
+
+describe('uploadId — VER-INSERT-01 (always INSERT, never UPSERT)', () => {
+  test('VER-INSERT-01: uploadId inserts a new row and does not call update or upsert', async () => {
+    const usersChain = makeChain({
+      data: { id: 'uuid-insert-test', full_name: 'Alice Smith', email: 'alice@test.com', phone: null, dob: null, role: 'provider' },
+      error: null,
+    });
+
+    // verifications.insert() is the terminal call — must return a Promise directly.
+    const verificationChain = {
+      insert: jest.fn().mockResolvedValue({ error: null }),
+    };
+
+    supabaseMock.from = jest.fn()
+      .mockReturnValueOnce(usersChain)          // getInternalUser → users table
+      .mockReturnValueOnce(verificationChain);  // verifications.insert()
+
+    storageMock.uploadVerificationDocument.mockResolvedValue({ success: true, path: 'test/id.jpg' });
+    storageMock.getSignedUrl.mockResolvedValue({ success: true, signedUrl: 'http://mock.url/id.jpg' });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ extractedName: 'Alice Smith', status: 'verified' }),
+    });
+
+    const req = {
+      user: { id: 'supabase-uid-insert' },
+      file: { mimetype: 'image/jpeg', size: 1000, buffer: Buffer.from('x'), originalname: 'id.jpg' },
+      body: { documentType: 'drivers_license' },
+    };
+    const res = mockRes();
+    await uploadId(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    expect(verificationChain.insert).toHaveBeenCalledTimes(1);
+    expect(verificationChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: 'uuid-insert-test', verification_status: 'pending' })
+    );
+  });
+});
+
+// ── VER-SELFIE-01/02 ─────────────────────────────────────────────────────
+
+describe('uploadSelfie — face_match_score and stack trace', () => {
+  test('VER-SELFIE-01: face_match_score is stored from faceMatchResult.similarity', async () => {
+    const usersChain = makeChain({
+      data: { id: 'uuid-selfie-test', full_name: 'Carol Jones', email: 'carol@test.com', phone: null, dob: null, role: 'provider' },
+      error: null,
+    });
+
+    // Lookup chain: select().eq().order().limit(1).maybeSingle() returns existing verification row.
+    const verificationLookupChain = makeChain({
+      data: { id: 'verif-row-1', id_document_url: 'test/id.jpg' },
+      error: null,
+    });
+
+    // Update chain: update() chains; eq() is the terminal call.
+    const verificationUpdateChain = {
+      update: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    };
+
+    supabaseMock.from = jest.fn()
+      .mockReturnValueOnce(usersChain)               // getInternalUser → users table
+      .mockReturnValueOnce(verificationLookupChain)  // verifications select (find existing row)
+      .mockReturnValueOnce(verificationUpdateChain); // verifications update (store face match)
+
+    storageMock.uploadVerificationDocument.mockResolvedValue({ success: true, path: 'test/selfie.jpg' });
+    storageMock.getSignedUrl.mockResolvedValue({ success: true, signedUrl: 'http://mock.url/file.jpg' });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ similarity: 92.5, matched: true, status: 'verified' }),
+    });
+
+    const req = {
+      user: { id: 'supabase-uid-selfie' },
+      file: { mimetype: 'image/jpeg', size: 1000, buffer: Buffer.from('x'), originalname: 'selfie.jpg' },
+      body: {},
+    };
+    const res = mockRes();
+    await uploadSelfie(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    expect(verificationUpdateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({ face_match_score: 92.5 })
+    );
+  });
+
+  test('VER-SELFIE-02: uploadSelfie 500 body does not contain stack trace', async () => {
+    const dbErr = new Error('Selfie DB connection failed');
+    dbErr.stack = 'Error: Selfie DB connection failed\n    at Object.<anonymous> (verificationController.js:200)';
+    supabaseMock.from = jest.fn().mockImplementation(() => { throw dbErr; });
+
+    const req = {
+      user: { id: 'supabase-uid-selfie-err' },
+      file: { mimetype: 'image/jpeg', size: 1000, buffer: Buffer.from('x'), originalname: 'selfie.jpg' },
+      body: {},
+    };
+    const res = mockRes();
+    await uploadSelfie(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    const body = res.json.mock.calls[0][0];
+    const serialised = JSON.stringify(body);
+    expect(serialised).not.toMatch(/at Object\./);
+    expect(serialised).not.toMatch(/Selfie DB connection failed/);
+    expect(body.error).toBe('Failed to process selfie image. Please try again.');
   });
 });

--- a/context.md
+++ b/context.md
@@ -1,43 +1,540 @@
-# Bug-Fix-2 Session Context
+# Bug-Fix-3 — Session Context
 
-Branch: feat/Bug-Fix-2
-Last updated: 2026-05-04T04:00:00Z
-Last completed chunk: 7 (ALL DONE)
+**Branch:** `feat/Bug-Fix-3`
+**Last updated:** 2026-05-06
+**Current phase:** Phase 2 — Complete
+**Last completed step:** Step 5 — All 16 steps done, all tests green
 
-## Chunk Status
-- [x] Chunk 1 — AI-CRIT-01 / AI-HIGH-02: Dev-mode bypass warnings + ENV validation
-- [x] Chunk 2 — AI-CRIT-02: Face match threshold sourced from settings
-- [x] Chunk 3 — AI-HIGH-01: Combined timeout on legacy face_route downloads
-- [x] Chunk 4 — AI-HIGH-03: Replace test_api_routes.py with strict tests
-- [x] Chunk 5 — AI-MED-01: MIME / magic-byte validation on uploads
-- [x] Chunk 6 — AI-MED-02: Passport plain-text fallback
-- [x] Chunk 7 — AI-LOW-01: NSOPW pending observability
+---
 
-## Files modified this session
-- ai-services/app/routes/ocr_routes.py — verify_internal_key: warning on dev bypass, error on unknown ENV
-- ai-services/app/routes/face_routes.py — same as ocr_routes
-- ai-services/app/routes/nsopw_routes.py — same as ocr_routes
-- ai-services/app/main.py — added logger; startup ENV validation in lifespan
-- ai-services/app/services/face_service.py — removed FACE_MATCH_THRESHOLD constant; reads settings.FACE_MATCH_THRESHOLD at call time
-- ai-services/app/routes/verification.py — added asyncio import + _fetch_face_images helper; verify_face now uses asyncio.wait_for(timeout=25.0) with except asyncio.TimeoutError → 504
+## Work completed before this session
 
-## Tests added / changed
-- tests/test_chunk1_bypass_warnings.py::test_rt15_bypass_logs_warning — Chunk 1
-- tests/test_chunk1_bypass_warnings.py::test_aisec06_dev_mode_accessible_without_key — Chunk 1
-- tests/test_chunk1_bypass_warnings.py::test_aisec02_empty_key_production — Chunk 1
-- tests/test_chunk1_bypass_warnings.py::test_aisec03_wrong_key_production — Chunk 1
-- tests/test_chunk1_bypass_warnings.py::test_unknown_env_enforces_key — Chunk 1
-- tests/test_face_service.py::test_face_ut01_high_similarity_verified — Chunk 2
-- tests/test_face_service.py::test_face_ut02_low_similarity_rejected — Chunk 2
-- tests/test_face_service.py::test_face_ut03_threshold_from_settings — Chunk 2
-- tests/test_verification_timeout.py::test_verify_face_timeout_returns_504 — Chunk 3
+| ID | Description | Status |
+|----|-------------|--------|
+| Bug A | DOB not shown in verification prefill | ✅ Fixed (`getPrefill` — single query, `dob` in SELECT) |
+| Bug A (frontend guard) | `userId` empty → prefill fetch silently skipped | ✅ Fixed (session fallback added) |
+| Bug B-B2 | Stack trace leaked from `uploadId` 500 response | ✅ Fixed (safe string returned) |
+| OCR DL doc number | "Not found" for driver's licenses — broken date filter + missing all-digit patterns | ✅ Fixed (`ocr_service.py`) |
 
-## Pending notes / decisions / follow-ups
-- verification.py legacy route also has no auth bypass warning (verify_internal_key not updated there) — note for Bug-Fix-3 if needed; legacy route is out of scope per Chunk 1 definition
-- verification.py legacy route hardcodes threshold_used: 90.0 in its response — deferred to Bug-Fix-3 per Chunk 2 scope rules
+---
+
+## Bugs in scope — Phase 2
+
+| ID | Description | File(s) | Status |
+|----|-------------|---------|--------|
+| P2-1 | `uploadId` UPSERT overwrites previous attempts — no per-attempt history | `verificationController.js` | ✅ Fixed |
+| P2-2 | `face_match_score` always 0.0 — backend extracts wrong field (`similarity_score` vs `similarity`) | `verificationController.js:314` | ✅ Fixed |
+| P2-3 | Stack trace leak in `uploadSelfie` 500 response (same pattern as fixed Bug B-B2, different function) | `verificationController.js:329` | ✅ Fixed |
+| P2-4 | "Document OCR: Not yet scanned" — UI reads `ocr_result.extracted_data.full_name` (never exists); data is stored flat as `ocr_result.extractedName` | `VerificationDetailsModal.tsx` | ✅ Fixed |
+| P2-5 | Face Match similarity always "—", match always "❌ No" — UI reads `similarity_score`/`is_match`; stored as `similarity`/`matched` | `VerificationDetailsModal.tsx` | ✅ Fixed |
+| P2-6 | NSOPW status never shown — UI reads `nsopw_result.status`/`is_clear`; stored as `nsopwStatus`/`matchFound` | `VerificationDetailsModal.tsx` | ✅ Fixed |
+| P2-7 | Registry only hits NSOPW.gov scraper regardless of jurisdiction; faster direct REST APIs exist for IA, MO, DC, Chicago | `nsopw_service.py`, `nsopw_routes.py`, `verificationController.js` | ✅ Fixed |
+| P2-8 | Existing tests VER-PREFILL-01/02 will break — they mock two DB calls but `getPrefill` now makes one; mock data missing `dob` | `verificationPrefill.test.js` | ✅ Fixed |
+
+---
+
+## Architecture decisions
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| Schema: new `verification_attempts` tables vs fix in place | **Fix in place** — keep single `verifications` table, change UPSERT → INSERT | Smaller blast radius; unblocks the display bug faster |
+| Registry: replace NSOPW vs route on top | **Route on top** — IA/MO/DC/Chicago REST APIs short-circuit before Playwright NSOPW | Keeps existing fallback, adds coverage for four jurisdictions |
+| OCR route: legacy JSON+URL vs new multipart | **Keep legacy** `/api/v1/verify/document` | No change to call pattern; RT-14 test already validates legacy route stays registered |
+| Field normalization layer | **Frontend** (`VerificationDetailsModal.tsx`) + **backend extraction fix** (line 314) | Changing the Python service would break all OCR test assertions (`extractedName` etc.); frontend fix is one file, zero test breakage |
+
+---
+
+## Root cause map
+
+### P2-1 — UPSERT overwrites attempts
+```
+uploadId (line 167-192):
+  → SELECT latest verifications row for user_id
+  → If found: UPDATE it            ← obliterates previous OCR result
+  → If not found: INSERT new row
+```
+Fix: remove the find-and-update branch; always INSERT.
+
+### P2-2 + P2-3 — uploadSelfie bugs
+```
+Line 314:  face_match_score: faceMatchResult?.similarity_score || 0.0
+                                               ^^^^^^^^^^^^^^^^
+           AI service returns `similarity`, not `similarity_score` → always 0.0
+
+Line 329:  error: err.stack || err.message || 'Failed to process selfie'
+                   ^^^^^^^^^
+           Leaks stack trace to client
+```
+
+### P2-4/5/6 — VerificationDetailsModal field mismatch
+
+What the AI service stores in JSONB columns vs what the UI tries to read:
+
+| Column | Stored key (AI output) | UI reads | Bug |
+|--------|----------------------|----------|-----|
+| `ocr_result` | `extractedName` | `extracted_data.full_name` | "Not yet scanned" |
+| `ocr_result` | `extractedDOB` | `extracted_data.date_of_birth` | "—" |
+| `ocr_result` | `documentNumber` | `extracted_data.id_number` | "—" |
+| `ocr_result` | `confidence` | `confidence_score` | confidence hidden |
+| `face_match_result` | `similarity` | `similarity_score` | "—" |
+| `face_match_result` | `matched` | `is_match` | always "❌ No" |
+| `nsopw_result` | `nsopwStatus` | `status` | status hidden |
+| `nsopw_result` | `matchFound` | `is_clear` (inverted) | "—" |
+
+### P2-7 — Registry jurisdiction routing
+```
+submitVerification → POST /ai/nsopw/check → nsopw_service.check_nsopw()
+                                                 ↓
+                                         Playwright NSOPW.gov (always)
+```
+Fix: add routing layer in `nsopw_service.py` — check state/city first, call specific REST APIs for IA/MO/DC/Chicago, fall back to Playwright NSOPW for everything else.
+
+City extraction note: the backend currently doesn't pass `city` to the NSOPW call. For Chicago routing, we need `city`. Add city parsing in `submitVerification` from the OCR address string and add an optional `city` field to `NsopwCheckBody`.
+
+### P2-8 — Broken existing tests
+After the Bug A fix, `getPrefill` now makes **one** Supabase call (via `getInternalUser`) instead of two. The existing tests mock two calls and the mock data for the first call lacks `dob`. Both VER-PREFILL-01 and VER-PREFILL-02 will fail until updated.
+
+---
+
+## Implementation walkthrough
+
+### Step 1 — Backend: three fixes in `verificationController.js`
+
+**File:** `backend/src/controllers/verificationController.js`
+
+#### 1a — UPSERT → INSERT (P2-1)
+Remove lines 167–192 (the "find existing or create" block). Replace with a single INSERT:
+```js
+const { error: insertError } = await supabase
+  .from('verifications')
+  .insert({ user_id: internalUser.id, ...verificationPayload });
+if (insertError) {
+  console.error('Verification insert error:', insertError.message);
+}
+```
+`uploadSelfie` and `submitVerification` already use `.order('created_at', { ascending: false }).limit(1).maybeSingle()` to find the latest record — no changes needed there.
+
+#### 1b — Fix face_match_score extraction (P2-2)
+Line 314:
+```js
+// Before
+face_match_score: faceMatchResult?.similarity_score || 0.0,
+// After
+face_match_score: faceMatchResult?.similarity ?? 0.0,
+```
+(`??` used instead of `||` so a genuine 0.0 score is not replaced by the default.)
+
+#### 1c — Fix uploadSelfie stack trace leak (P2-3)
+Line 329:
+```js
+// Before
+error: err.stack || err.message || 'Failed to process selfie'
+// After
+error: 'Failed to process selfie image. Please try again.'
+```
+
+#### 1d — Add city extraction + pass to NSOPW call (needed for P2-7)
+In `submitVerification`, after the ZIP extraction block (after line ~421), add:
+```js
+// Extract city from OCR address for jurisdiction routing
+let city = null;
+if (typeof ocrAddress === 'string') {
+  const cityMatch = ocrAddress.match(/,\s*([A-Za-z\s]+),\s*[A-Z]{2}/);
+  if (cityMatch) city = cityMatch[1].trim();
+}
+```
+Then update the NSOPW `fetch` body (line ~436) to include `city`:
+```js
+body: JSON.stringify({ firstName, lastName, state, zipCode, city }),
+```
+
+---
+
+### Step 2 — Frontend: fix VerificationDetailsModal field mappings (P2-4/5/6)
+
+**File:** `frontend/src/components/VerificationDetailsModal.tsx`
+
+#### 2a — Update `VerificationData` interface
+Replace the three nested result interfaces with the actual shapes the AI service returns and stores:
+```ts
+ocr_result?: {
+  status?: string;
+  extractedName?: string;
+  extractedDOB?: string;
+  documentNumber?: string;
+  expiryDate?: string;
+  issuingState?: string;
+  confidence?: number;
+  rejectionReason?: string | null;
+};
+face_match_result?: {
+  status?: string;
+  similarity?: number;
+  matched?: boolean;
+  faceDetectedInId?: boolean;
+  faceDetectedInSelfie?: boolean;
+};
+nsopw_result?: {
+  nsopwStatus?: string;
+  matchFound?: boolean;
+  matchDetails?: unknown[];
+};
+```
+
+#### 2b — Fix OCR section reads
+```ts
+// Before
+const ocrData = data?.ocr_result?.extracted_data;
+// After — read directly from ocr_result
+const ocrResult = data?.ocr_result;
+```
+Update the JSX to render `ocrResult?.extractedName`, `ocrResult?.extractedDOB`, `ocrResult?.documentNumber`, `ocrResult?.confidence`.
+The "Not yet scanned" condition changes from `!ocrData` to `!ocrResult?.extractedName && !ocrResult?.extractedDOB`.
+
+#### 2c — Fix Face Match reads
+```ts
+// Before
+faceData?.similarity_score   →   faceData?.similarity
+faceData?.is_match           →   faceData?.matched
+```
+
+#### 2d — Fix NSOPW reads
+```ts
+// Before
+nsopwData?.status            →   nsopwData?.nsopwStatus
+nsopwData?.is_clear          →   !nsopwData?.matchFound
+nsopwData?.used_fallback     →   remove (field doesn't exist)
+```
+
+---
+
+### Step 3 — AI Service: add registry jurisdiction routing (P2-7)
+
+#### 3a — `ai-services/app/routes/nsopw_routes.py`
+Add `city` as an optional field to `NsopwCheckBody`:
+```python
+city: Optional[str] = Field(None, description="City name, used for Chicago jurisdiction routing")
+```
+Pass it through to the service call:
+```python
+result = await nsopw_service.check_nsopw(
+    first_name=body.firstName,
+    last_name=body.lastName,
+    state=body.state,
+    zip_code=body.zipCode,
+    city=body.city,          # new
+)
+```
+
+#### 3b — `ai-services/app/services/nsopw_service.py`
+Add `city: Optional[str] = None` to `check_nsopw` signature.
+
+Add four helper coroutines **before** the existing `check_nsopw` function:
+
+```python
+async def _check_iowa(first_name: str, last_name: str) -> dict:
+    """Iowa Sex Offender Registry — GET JSON API (50 req/hr cap)."""
+    url = "https://www.iowasexoffender.gov/api/search/results.json"
+    params = {"lastname": last_name, "firstname": first_name}
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    records = data if isinstance(data, list) else data.get("results", [])
+    match_found = len(records) > 0
+    return {
+        "nsopwStatus": "fail" if match_found else "pass",
+        "matchFound": match_found,
+        "matchDetails": [{"name": r.get("name", "")} for r in records[:5]],
+        "checkedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "iowasexoffender.gov",
+    }
+
+
+async def _check_missouri(first_name: str, last_name: str) -> dict:
+    """Missouri MSHP Sex Offender Registry — ArcGIS REST query."""
+    url = (
+        "https://www.mshp.dps.missouri.gov/arcgis/rest/services"
+        "/NSOR/MapServer/7/query"
+    )
+    where = f"LAST_NAME='{last_name.upper()}' AND FIRST_NAME='{first_name.upper()}'"
+    params = {
+        "where": where,
+        "outFields": "FIRST_NAME,LAST_NAME,CITY",
+        "f": "json",
+        "resultRecordCount": 10,
+    }
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    features = data.get("features", [])
+    match_found = len(features) > 0
+    return {
+        "nsopwStatus": "fail" if match_found else "pass",
+        "matchFound": match_found,
+        "matchDetails": [
+            {"name": f"{f['attributes'].get('FIRST_NAME','')} {f['attributes'].get('LAST_NAME','')}".strip()}
+            for f in features[:5]
+        ],
+        "checkedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "mshp.dps.missouri.gov",
+    }
+
+
+async def _check_dc(first_name: str, last_name: str) -> dict:
+    """Washington D.C. Sex Offender Registry — DC GIS FeatureServer query."""
+    url = (
+        "https://maps2.dcgis.dc.gov/dcgis/rest/services"
+        "/FEEDS/MPD/FeatureServer/20/query"
+    )
+    where = f"LASTNAME='{last_name.upper()}' AND FIRSTNAME='{first_name.upper()}'"
+    params = {"where": where, "outFields": "*", "f": "json", "resultRecordCount": 10}
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    features = data.get("features", [])
+    match_found = len(features) > 0
+    return {
+        "nsopwStatus": "fail" if match_found else "pass",
+        "matchFound": match_found,
+        "matchDetails": [
+            {"name": f"{f['attributes'].get('FIRSTNAME','')} {f['attributes'].get('LASTNAME','')}".strip()}
+            for f in features[:5]
+        ],
+        "checkedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "maps2.dcgis.dc.gov",
+    }
+
+
+async def _check_chicago(first_name: str, last_name: str) -> dict:
+    """Chicago Sex Offender Registry — Socrata open data API."""
+    url = "https://data.cityofchicago.org/resource/vc9r-bqvy.json"
+    params = {"LASTNAME": last_name.upper(), "FIRSTNAME": first_name.upper()}
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        records = resp.json()
+    match_found = len(records) > 0
+    return {
+        "nsopwStatus": "fail" if match_found else "pass",
+        "matchFound": match_found,
+        "matchDetails": [
+            {"name": f"{r.get('FIRSTNAME','')} {r.get('LASTNAME','')}".strip()}
+            for r in records[:5]
+        ],
+        "checkedAt": datetime.now(timezone.utc).isoformat(),
+        "source": "data.cityofchicago.org",
+    }
+```
+
+Add routing at the **top** of `check_nsopw` (before the existing Playwright call):
+```python
+async def check_nsopw(
+    first_name: str,
+    last_name: str,
+    state: Optional[str] = None,
+    zip_code: Optional[str] = None,
+    city: Optional[str] = None,          # new param
+) -> Dict[str, Any]:
+    state_upper = (state or "").upper()
+    city_upper = (city or "").upper()
+
+    # ── Jurisdiction routing (REST APIs — faster, no browser) ─────────────
+    try:
+        if state_upper == "IA":
+            return await _check_iowa(first_name, last_name)
+        if state_upper == "MO":
+            return await _check_missouri(first_name, last_name)
+        if state_upper == "DC":
+            return await _check_dc(first_name, last_name)
+        if state_upper == "IL" and city_upper == "CHICAGO":
+            return await _check_chicago(first_name, last_name)
+    except Exception as exc:
+        logger.error("Jurisdiction REST API failed (%s): %s", state_upper, type(exc).__name__)
+        # Fall through to NSOPW Playwright scraper below
+
+    # ── Default: NSOPW Playwright scraper ────────────────────────────────
+    # ... (existing code unchanged)
+```
+
+---
+
+### Step 4 — Tests: backend (P2-8 + new coverage)
+
+**File:** `backend/src/tests/verificationPrefill.test.js`
+
+#### 4a — Fix VER-PREFILL-01
+The test currently mocks two `supabase.from` calls. After the Bug A fix, `getPrefill` makes one call. Update:
+- Add `dob: '1990-03-15'` to `internalChain` data
+- Remove `prefillChain` and the second `mockReturnValueOnce`
+- Change `supabaseMock.from = jest.fn().mockReturnValueOnce(internalChain)` (single chain)
+
+#### 4b — Fix VER-PREFILL-02
+Same pattern: add `dob: null` to `internalChain` data, remove `prefillChain`.
+
+#### 4c — Add VER-SELFIE-01: face_match_score uses `similarity`
+```js
+test('VER-SELFIE-01: face_match_score stored from similarity not similarity_score', async () => {
+  // mock getInternalUser → user found
+  // mock verifications lookup → record with id_document_url set
+  // mock getSignedUrl → both signed URLs returned
+  // mock fetch (AI face service) → { similarity: 87.5, matched: true, status: 'verified' }
+  // mock verifications update → success
+  // assert update was called with face_match_score: 87.5
+});
+```
+
+#### 4d — Add VER-SELFIE-02: uploadSelfie 500 does not leak stack trace
+Mirrors VER-UPLOAD-01 but for `uploadSelfie`:
+```js
+test('VER-SELFIE-02: 500 body does not contain stack trace', async () => {
+  // throw from supabase.from
+  // assert res.status(500) called
+  // assert body.error === 'Failed to process selfie image. Please try again.'
+  // assert body does not contain 'at Object.' or DB error message
+});
+```
+
+#### 4e — Add VER-INSERT-01: uploadId always INSERTs a new row
+```js
+test('VER-INSERT-01: uploadId inserts a new verifications row even when one already exists', async () => {
+  // mock getInternalUser → user found
+  // mock file upload → success
+  // mock getSignedUrl → success
+  // mock fetch (AI OCR) → { extractedName: 'Jane Doe', extractedDOB: '1990-01-01', status: 'verified' }
+  // mock supabase.insert → success (do NOT mock .select.eq... which would imply UPSERT check)
+  // assert insert was called (not update)
+  // assert insert was called with user_id and ocr_result
+});
+```
+
+---
+
+### Step 5 — Tests: Python registry routing
+
+**New file:** `ai-services/tests/test_registry_routing.py`
+
+```python
+"""
+test_registry_routing.py — REG-01 through REG-06
+Verifies jurisdiction routing in check_nsopw().
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.mark.asyncio
+async def test_reg01_iowa_routes_to_rest_api():
+    """REG-01: state=IA routes to Iowa REST API, not NSOPW scraper."""
+    # patch _check_iowa to return pass result
+    # assert check_nsopw(state="IA") calls _check_iowa
+    # assert source == "iowasexoffender.gov"
+
+@pytest.mark.asyncio
+async def test_reg02_missouri_routes_to_rest_api():
+    """REG-02: state=MO routes to Missouri ArcGIS REST API."""
+
+@pytest.mark.asyncio
+async def test_reg03_dc_routes_to_rest_api():
+    """REG-03: state=DC routes to DC GIS REST API."""
+
+@pytest.mark.asyncio
+async def test_reg04_chicago_routes_to_socrata():
+    """REG-04: state=IL + city=Chicago routes to Chicago Socrata API."""
+
+@pytest.mark.asyncio
+async def test_reg05_illinois_non_chicago_uses_nsopw():
+    """REG-05: state=IL + city=Springfield falls through to NSOPW (not Chicago API)."""
+
+@pytest.mark.asyncio
+async def test_reg06_rest_api_failure_falls_through_to_nsopw():
+    """REG-06: if Iowa REST API raises an exception, falls through to NSOPW scraper."""
+    # patch _check_iowa to raise httpx.HTTPError
+    # patch the Playwright NSOPW path to return pass
+    # assert final source is nsopw.gov
+```
+
+---
+
+## Test plan summary
+
+| Test ID | File | Type | Covers |
+|---------|------|------|--------|
+| VER-PREFILL-01 *(update)* | `verificationPrefill.test.js` | Unit | Bug A fix — single query, dob in mock |
+| VER-PREFILL-02 *(update)* | `verificationPrefill.test.js` | Unit | Bug A fix — null dob case |
+| VER-SELFIE-01 *(new)* | `verificationPrefill.test.js` | Unit | P2-2 — face_match_score from `similarity` |
+| VER-SELFIE-02 *(new)* | `verificationPrefill.test.js` | Unit | P2-3 — no stack trace leak in uploadSelfie |
+| VER-INSERT-01 *(new)* | `verificationPrefill.test.js` | Unit | P2-1 — always INSERT new row |
+| REG-01 *(new)* | `test_registry_routing.py` | Unit | Iowa routing |
+| REG-02 *(new)* | `test_registry_routing.py` | Unit | Missouri routing |
+| REG-03 *(new)* | `test_registry_routing.py` | Unit | DC routing |
+| REG-04 *(new)* | `test_registry_routing.py` | Unit | Chicago routing |
+| REG-05 *(new)* | `test_registry_routing.py` | Unit | IL non-Chicago falls to NSOPW |
+| REG-06 *(new)* | `test_registry_routing.py` | Unit | REST failure falls through to NSOPW |
+
+---
+
+## CI/CD requirements
+
+CI pipeline: `.github/workflows/ci.yml` — three relevant jobs.
+
+| Job | Trigger | Gate |
+|-----|---------|------|
+| `backend` | `npm test` (Jest) | Must pass: VER-PREFILL-01/02 (updated), new VER-* tests |
+| `ai-services` | `flake8 .` then `pytest` | Must pass: existing RT-* tests unchanged, new REG-* tests |
+| `frontend` | `npm run build` | TypeScript must compile after interface update in VerificationDetailsModal |
+
+**No CI workflow changes needed** — all new tests fall under existing jobs.
+
+**Env vars**: `AI_SERVICES_URL` and `AI_INTERNAL_API_KEY` are not in CI env blocks but are set directly inside the test file (`process.env.AI_SERVICES_URL = 'http://localhost:8000'` before the dynamic import) — this is intentional and works correctly.
+
+**flake8**: new `test_registry_routing.py` and changes to `nsopw_service.py` / `nsopw_routes.py` must pass `flake8` with no E/W errors. Max line length is whatever the existing `.flake8` config specifies (check before submitting).
+
+---
+
+## Files to touch
+
+| File | Change | Step |
+|------|--------|------|
+| `backend/src/controllers/verificationController.js` | UPSERT→INSERT, `similarity_score`→`similarity`, selfie stack trace fix, city extraction + NSOPW call | 1 |
+| `frontend/src/components/VerificationDetailsModal.tsx` | Interface + field reads for OCR/face/NSOPW | 2 |
+| `ai-services/app/routes/nsopw_routes.py` | Add `city` optional field to `NsopwCheckBody` | 3a |
+| `ai-services/app/services/nsopw_service.py` | Add `city` param, four REST helper coroutines, routing block at top of `check_nsopw` | 3b |
+| `backend/src/tests/verificationPrefill.test.js` | Fix VER-PREFILL-01/02, add VER-SELFIE-01/02, VER-INSERT-01 | 4 |
+| `ai-services/tests/test_registry_routing.py` | New file — REG-01 through REG-06 | 5 |
+
+---
+
+## Progress tracker
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1a | `uploadId` UPSERT → INSERT | ✅ |
+| 1b | `face_match_score` field fix (`similarity`) | ✅ |
+| 1c | `uploadSelfie` stack trace fix | ✅ |
+| 1d | City extraction + pass to NSOPW call | ✅ |
+| 2a | `VerificationData` interface update | ✅ |
+| 2b | OCR section reads fix | ✅ |
+| 2c | Face Match reads fix | ✅ |
+| 2d | NSOPW reads fix | ✅ |
+| 3a | `NsopwCheckBody` — add `city` field | ✅ |
+| 3b | `nsopw_service.py` — routing + four helpers | ✅ |
+| 4a | VER-PREFILL-01 test fix | ✅ |
+| 4b | VER-PREFILL-02 test fix | ✅ |
+| 4c | VER-SELFIE-01 new test | ✅ |
+| 4d | VER-SELFIE-02 new test | ✅ |
+| 4e | VER-INSERT-01 new test | ✅ |
+| 5 | REG-01 through REG-06 new Python tests | ✅ |
+
+---
 
 ## How to resume after interruption
-1. `git checkout feat/Bug-Fix-2`
-2. `cd ai-services && python -m pytest -v` — all green expected
-3. Re-read this file
-4. Resume at "Last completed chunk" + 1
+
+1. `git checkout feat/Bug-Fix-3`
+2. Re-read this file (`context.md`)
+3. Find the first ⬜ row in the progress tracker
+4. Read the corresponding step in the "Implementation walkthrough" section above
+5. Implement, run tests locally, mark ✅, move to next step
+6. When all steps are ✅ — run `npm test` (backend) and `pytest` (ai-services), confirm CI green

--- a/frontend/src/components/VerificationDetailsModal.tsx
+++ b/frontend/src/components/VerificationDetailsModal.tsx
@@ -49,6 +49,15 @@ interface VerificationData {
   created_at?: string;
 }
 
+const STATUS_LABELS: Record<string, string> = {
+  verified: "Verified",
+  pending: "Under Review",
+  manual_review: "Under Manual Review",
+  rejected: "Not Verified",
+  failed: "Not Verified",
+  unverified: "Not Verified",
+};
+
 const StatusIcon: React.FC<{ status?: string }> = ({ status }) => {
   switch (status) {
     case "verified":
@@ -155,8 +164,8 @@ export const VerificationDetailsModal: React.FC<
                     ${data.verification_status === "unverified" ? "bg-slate-100 text-slate-600" : ""}`}
                 >
                   <StatusIcon status={data.verification_status} />
-                  {data.verification_status.charAt(0).toUpperCase() +
-                    data.verification_status.slice(1)}
+                  {STATUS_LABELS[data.verification_status] ??
+                    data.verification_status}
                 </span>
               </div>
 

--- a/frontend/src/components/VerificationDetailsModal.tsx
+++ b/frontend/src/components/VerificationDetailsModal.tsx
@@ -58,6 +58,13 @@ const STATUS_LABELS: Record<string, string> = {
   unverified: "Not Verified",
 };
 
+const overallBadgeClass = (status: string) => {
+  if (status === "verified") return "bg-emerald-100 text-emerald-700";
+  if (status === "pending" || status === "manual_review") return "bg-amber-100 text-amber-700";
+  if (status === "failed" || status === "rejected") return "bg-red-100 text-red-700";
+  return "bg-slate-100 text-slate-600";
+};
+
 const StatusIcon: React.FC<{ status?: string }> = ({ status }) => {
   switch (status) {
     case "verified":

--- a/frontend/src/components/VerificationDetailsModal.tsx
+++ b/frontend/src/components/VerificationDetailsModal.tsx
@@ -24,25 +24,25 @@ interface VerificationData {
   extracted_dob?: string;
   ocr_result?: {
     status?: string;
-    extracted_data?: {
-      full_name?: string;
-      date_of_birth?: string;
-      id_number?: string;
-      expiration_date?: string;
-      issue_state?: string;
-    };
-    confidence_score?: number;
+    extractedName?: string;
+    extractedDOB?: string;
+    documentNumber?: string;
+    expiryDate?: string;
+    issuingState?: string;
+    confidence?: number;
+    rejectionReason?: string | null;
   };
   face_match_result?: {
     status?: string;
-    similarity_score?: number;
-    is_match?: boolean;
-    threshold_used?: number;
+    similarity?: number;
+    matched?: boolean;
+    faceDetectedInId?: boolean;
+    faceDetectedInSelfie?: boolean;
   };
   nsopw_result?: {
-    status?: string;
-    is_clear?: boolean;
-    used_fallback?: boolean;
+    nsopwStatus?: string;
+    matchFound?: boolean;
+    matchDetails?: unknown[];
   };
   submitted_at?: string;
   reviewed_at?: string;
@@ -51,11 +51,18 @@ interface VerificationData {
 
 const STATUS_LABELS: Record<string, string> = {
   verified: "Verified",
-  pending: "Under Review",
-  manual_review: "Under Manual Review",
+  pending: "Manual Review",
+  manual_review: "Manual Review",
   rejected: "Not Verified",
   failed: "Not Verified",
-  unverified: "Not Verified",
+  unverified: "Not Started",
+};
+
+const overallBadgeClass = (status: string) => {
+  if (status === "verified") return "bg-emerald-100 text-emerald-700";
+  if (status === "pending" || status === "manual_review") return "bg-amber-100 text-amber-700";
+  if (status === "failed" || status === "rejected") return "bg-red-100 text-red-700";
+  return "bg-slate-100 text-slate-600";
 };
 
 const StatusIcon: React.FC<{ status?: string }> = ({ status }) => {
@@ -101,9 +108,20 @@ export const VerificationDetailsModal: React.FC<
 
   if (!isOpen) return null;
 
-  const ocrData = data?.ocr_result?.extracted_data;
+  const ocrResult = data?.ocr_result;
   const faceData = data?.face_match_result;
   const nsopwData = data?.nsopw_result;
+
+  // Derive section-level status from actual result fields, not the AI's `status` string.
+  // The AI may store status="rejected" even when fields were extracted (low confidence),
+  // or status="verified" even when face match failed — so we check real data.
+  const ocrStatus: string | undefined =
+    ocrResult?.extractedName || ocrResult?.extractedDOB ? "verified" : ocrResult?.status;
+
+  const faceStatus: string | undefined =
+    faceData?.matched === true ? "verified" :
+    faceData?.matched === false ? "rejected" :
+    faceData?.status;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -157,11 +175,7 @@ export const VerificationDetailsModal: React.FC<
                   Overall Status
                 </span>
                 <span
-                  className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-bold
-                    ${data.verification_status === "verified" ? "bg-emerald-100 text-emerald-700" : ""}
-                    ${data.verification_status === "pending" ? "bg-amber-100 text-amber-700" : ""}
-                    ${data.verification_status === "failed" ? "bg-red-100 text-red-700" : ""}
-                    ${data.verification_status === "unverified" ? "bg-slate-100 text-slate-600" : ""}`}
+                  className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-bold ${overallBadgeClass(data.verification_status)}`}
                 >
                   <StatusIcon status={data.verification_status} />
                   {STATUS_LABELS[data.verification_status] ??
@@ -176,28 +190,28 @@ export const VerificationDetailsModal: React.FC<
                   <span className="text-sm font-bold text-slate-700">
                     Document OCR
                   </span>
-                  <StatusIcon status={data.ocr_result?.status} />
+                  <StatusIcon status={ocrStatus} />
                 </div>
-                {ocrData ? (
+                {ocrResult?.extractedName || ocrResult?.extractedDOB ? (
                   <div className="space-y-1.5 text-sm">
                     <p className="text-slate-600">
                       <span className="font-medium text-slate-800">Name:</span>{" "}
-                      {ocrData.full_name || "—"}
+                      {ocrResult.extractedName || "—"}
                     </p>
                     <p className="text-slate-600">
                       <span className="font-medium text-slate-800">DOB:</span>{" "}
-                      {ocrData.date_of_birth || "—"}
+                      {ocrResult.extractedDOB || "—"}
                     </p>
                     <p className="text-slate-600">
                       <span className="font-medium text-slate-800">
                         ID Number:
                       </span>{" "}
-                      {ocrData.id_number || "—"}
+                      {ocrResult.documentNumber || "—"}
                     </p>
-                    {data.ocr_result?.confidence_score !== undefined && (
+                    {ocrResult.confidence !== undefined && (
                       <p className="text-slate-400 text-xs mt-1">
                         Confidence:{" "}
-                        {(data.ocr_result.confidence_score * 100).toFixed(1)}%
+                        {(ocrResult.confidence * 100).toFixed(1)}%
                       </p>
                     )}
                   </div>
@@ -213,7 +227,7 @@ export const VerificationDetailsModal: React.FC<
                   <span className="text-sm font-bold text-slate-700">
                     Face Match
                   </span>
-                  <StatusIcon status={faceData?.status} />
+                  <StatusIcon status={faceStatus} />
                 </div>
                 {faceData ? (
                   <div className="space-y-1.5 text-sm">
@@ -221,11 +235,11 @@ export const VerificationDetailsModal: React.FC<
                       <span className="font-medium text-slate-800">
                         Similarity:
                       </span>{" "}
-                      {faceData.similarity_score?.toFixed(1) ?? "—"}%
+                      {faceData.similarity?.toFixed(1) ?? "—"}%
                     </p>
                     <p className="text-slate-600">
                       <span className="font-medium text-slate-800">Match:</span>{" "}
-                      {faceData.is_match ? "✅ Yes" : "❌ No"}
+                      {faceData.matched ? "✅ Yes" : "❌ No"}
                     </p>
                   </div>
                 ) : (
@@ -240,7 +254,7 @@ export const VerificationDetailsModal: React.FC<
                   <span className="text-sm font-bold text-slate-700">
                     Background Check (NSOPW)
                   </span>
-                  <StatusIcon status={nsopwData?.status} />
+                  <StatusIcon status={nsopwData?.nsopwStatus} />
                 </div>
                 {nsopwData ? (
                   <div className="space-y-1.5 text-sm">
@@ -248,13 +262,8 @@ export const VerificationDetailsModal: React.FC<
                       <span className="font-medium text-slate-800">
                         Status:
                       </span>{" "}
-                      {nsopwData.is_clear ? "✅ Clear" : "⚠️ Review needed"}
+                      {nsopwData.matchFound === false ? "✅ Clear" : "⚠️ Review needed"}
                     </p>
-                    {nsopwData.used_fallback && (
-                      <p className="text-amber-600 text-xs">
-                        Used self-declaration fallback
-                      </p>
-                    )}
                   </div>
                 ) : (
                   <p className="text-sm text-slate-400">

--- a/frontend/src/pages/verify/index.tsx
+++ b/frontend/src/pages/verify/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import fetchApi from "../../lib/api";
 import { supabase } from "../../lib/supabase";
+import { toUserMessage } from "../../utils/errorMessages";
 import {
   Camera,
   Upload,
@@ -159,7 +160,7 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
         setError(json.error || "Failed to upload ID document.");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Network error");
+      setError(toUserMessage(err));
     } finally {
       setLoading(false);
     }
@@ -261,7 +262,7 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
         setError(json.error || "Failed to upload selfie.");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Network error");
+      setError(toUserMessage(err));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/verify/index.tsx
+++ b/frontend/src/pages/verify/index.tsx
@@ -57,6 +57,7 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
   const [idFile, setIdFile] = useState<File | null>(null);
   const [idPreview, setIdPreview] = useState<string | null>(null);
   const [ocrResult, setOcrResult] = useState<OcrResult | null>(null);
+  const [dobMismatch, setDobMismatch] = useState(false);
 
   // Step 3: Selfie Capture
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -73,8 +74,6 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
 
   // --- Step 1 logic ---
   useEffect(() => {
-    if (!userId) return;
-
     interface PrefillResponse {
       full_name: string;
       email: string;
@@ -84,9 +83,15 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
 
     let mounted = true;
     const fetchPrefill = async () => {
+      // Use the prop userId, but fall back to the live Supabase session uid so
+      // the fetch always runs even if the App state hasn't hydrated yet.
+      const { data: { session } } = await supabase.auth.getSession();
+      const uid = userId || session?.user?.id;
+      if (!uid) return;
+
       setLoading(true);
       setError(null);
-      const res = await fetchApi<PrefillResponse>(`/verification/prefill/${userId}`);
+      const res = await fetchApi<PrefillResponse>(`/verification/prefill/${uid}`);
       if (!mounted) return;
       if (res.success && res.data) {
         setPrefill({
@@ -156,6 +161,7 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
       const json = await res.json();
       if (res.ok && json.success) {
         setOcrResult(json.data.ocrResult);
+        setDobMismatch(!!json.data.dobMismatch);
       } else {
         setError(json.error || "Failed to upload ID document.");
       }
@@ -534,6 +540,15 @@ export const VerifyPage: React.FC<VerifyPageProps> = ({ userId, onNavigate }) =>
                       <p className="font-medium text-slate-900">{ocrResult.documentNumber || "Not found"}</p>
                     </div>
                   </div>
+
+                  {dobMismatch && (
+                    <div className="mb-5 p-3 bg-amber-50 border border-amber-200 rounded-xl flex items-start gap-2">
+                      <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0 text-amber-500" />
+                      <p className="text-sm text-amber-800">
+                        The date of birth on your ID document differs from your profile. Your profile has been automatically updated to match your ID.
+                      </p>
+                    </div>
+                  )}
                   <div className="flex gap-4">
                     <button
                       onClick={() => {

--- a/frontend/src/utils/errorMessages.ts
+++ b/frontend/src/utils/errorMessages.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function toUserMessage(_err: unknown): string {
+  return "Something went wrong while uploading. Please check your connection and try again.";
+}

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,0 +1,114 @@
+# Verification Flow — Walkthrough & Findings
+
+## Bug A — DOB not shown during verification
+
+### Data flow (as observed)
+
+1. User enters DOB at `frontend/src/pages/Register.tsx:222` via three `<select>` dropdowns (month/day/year); combined into `YYYY-MM-DD` string (lines 540, 558, 573); stored in state as `dob`.
+2. Submit handler calls `onRegister()` at line 463, which builds the registration payload with key `dob` and POSTs to `POST /api/auth/register` (`frontend/src/App.tsx:331`).
+3. Express handler at `backend/src/controllers/authController.js:11` destructures `dob` from `req.body`, validates 18+ age (lines 40-54), converts to ISO as `dobIso` (line 41).
+4. Persisted in TWO places:
+   - Supabase auth.users metadata: `data: { dob: dobIso }` (`authController.js:79`)
+   - `public.users` table, column `dob`: `.update({ dob: dobIso })` (`authController.js:108`)
+5. Verification screen (`frontend/src/pages/verify/index.tsx`) calls `GET /verification/prefill/${userId}` on mount (line 88).
+6. Express prefill handler at `backend/src/controllers/verificationController.js:62` runs:
+   ```js
+   .select('full_name, email, phone')   // ← 'dob' MISSING
+   ```
+7. Response is built at `verificationController.js:77` with:
+   ```js
+   date_of_birth: null,   // ← HARDCODED TO null
+   ```
+8. Frontend destructures `dateOfBirth: res.data.date_of_birth || ""` (verify/index.tsx:95) and renders `value={prefill?.dateOfBirth || "Not provided"}` (line 394) — always shows "Not provided".
+
+### Where it breaks
+
+**`backend/src/controllers/verificationController.js` lines 62 and 77.**
+The `getPrefill` controller selects only `full_name, email, phone` from `public.users`, omitting `dob`. The response then hardcodes `date_of_birth: null`. The DOB exists in the database (stored correctly during registration) but is never fetched or returned. The frontend has a working display path — it just always receives `null`.
+
+### Proposed fix
+
+- **`verificationController.js` line 62:** add `dob` to the SELECT → `.select('full_name, email, phone, dob')`
+- **`verificationController.js` line 77:** map it in the response → `date_of_birth: user.dob || null`
+- **Test:** integration test asserting that after a user is registered with a DOB, `GET /verification/prefill/:id` returns a non-null `date_of_birth`.
+
+---
+
+## Bug B — Improper error messages
+
+### Error sources catalogued
+
+| Source | Status | Body shape | Currently shown to user as |
+|--------|--------|-----------|----------------------------|
+| ai-services OCR — bad MIME | 400 | `{"detail": str(ValueError)}` | Raw Python ValueError message |
+| ai-services OCR — bad doc type | 400 | `{"detail": "document_type must be…"}` | Technical field-name string |
+| ai-services face — bad MIME | 400 | `{"detail": str(ValueError)}` | Raw Python ValueError message |
+| ai-services legacy verify — image download fail | 200* | `{"status":"manual_review","error":"Failed to download image: <httpx exc>"}` | Raw httpx exception string |
+| ai-services any route — Pydantic 422 | 422 | `{"detail": [{type, loc, msg, input}]}` | Not handled; raw array if shown |
+| Express verificationController uploadId | 500 | `{"error": err.stack \|\| err.message}` | Stack trace or JS error message |
+| Express global handler (dev) | 500 | `{"error": err.message, "stack": err.stack}` | Stack trace in dev mode |
+| Frontend network error (catch block) | N/A | `err.message` from TypeError/fetch | Raw JS exception message (e.g. "Failed to fetch") |
+| VerificationDetailsModal status | N/A | `verification_status` enum string | "manual_review", "pending" verbatim |
+
+*ai-services legacy route returns 200 with `status:"manual_review"` embedded in body even on error.
+
+### Where it breaks
+
+Three independent break points:
+
+**B1 — `frontend/src/pages/verify/index.tsx` lines 162 and 264:** Network errors in the `uploadId` and `uploadSelfie` fetch calls are caught and fed directly into `setError(err.message)`. A plain `TypeError: Failed to fetch` becomes the user-visible error string.
+
+**B2 — `backend/src/controllers/verificationController.js` line 216:** The `uploadId` handler catches unhandled errors and returns `error: err.stack || err.message`. Stack traces leak to the client when `err.stack` is set.
+
+**B3 — `frontend/src/components/VerificationDetailsModal.tsx` lines 158-159:** `verification_status` is rendered with only `charAt(0).toUpperCase()` normalisation — "manual_review" becomes "Manual_review" (shows underscore), "pending" shows "Pending" without context.
+
+There is **no error-code → user-friendly-string mapping layer** anywhere in the frontend.
+
+### Proposed fix
+
+- **B1 (frontend catch blocks):** Replace `setError(err.message)` with a `toUserMessage(err)` helper that maps known network/fetch errors to plain strings, with a safe fallback.
+- **B2 (Express uploadId 500):** Replace `err.stack || err.message` with a fixed string `"Failed to process ID document. Please try again."` (log the real error server-side only).
+- **B3 (status display):** Add a `STATUS_LABELS` map in the frontend that translates `verified → "Verified"`, `pending → "Under Review"`, `manual_review → "Under Manual Review"`, `failed/rejected → "Not Verified"`.
+
+---
+
+## Proposed Implementation Chunks
+
+### Chunk 1 — Fix DOB in prefill endpoint (Bug A)
+**Scope:** `backend/src/controllers/verificationController.js` only
+- Add `dob` to SELECT on line 62
+- Map `date_of_birth: user.dob || null` in response on line 77
+- **Tests:** Jest/supertest — `GET /verification/prefill/:id` returns `date_of_birth` equal to the value stored in the DB
+- **Do NOT touch:** frontend, auth controller, any other controller
+
+### Chunk 2 — Remove stack-trace / raw-error leakage from Express (Bug B-B2)
+**Scope:** `backend/src/controllers/verificationController.js` line 216 only
+- Replace `err.stack || err.message` with a fixed user-safe string; keep `console.error` for logging
+- **Tests:** test that a 500 response body does not contain `"stack"` or `"Error:"` patterns
+- **Do NOT touch:** global error handler in server.js (separate concern), frontend
+
+### Chunk 3 — Sanitise frontend network errors (Bug B-B1)
+**Scope:** `frontend/src/pages/verify/index.tsx` lines 162 and 264 only
+- Extract a `toUserMessage(err)` helper (inline in the file or a tiny `src/utils/errorMessages.ts`); map fetch/network errors to plain strings
+- **Tests:** unit test the helper for `TypeError: Failed to fetch`, `SyntaxError`, generic `Error`
+- **Do NOT touch:** any other page, the status modal
+
+### Chunk 4 — User-friendly status labels (Bug B-B3)
+**Scope:** `frontend/src/components/VerificationDetailsModal.tsx` only
+- Add a `STATUS_LABELS` constant mapping all known statuses to display strings
+- Replace the raw `charAt(0).toUpperCase()` call with a lookup
+- **Tests:** unit test that each known status maps to the expected label string, and unknown statuses fall back gracefully
+- **Do NOT touch:** any other component, backend
+
+---
+
+## Open questions for the user
+
+1. **Bug B — wording sign-off:** The error strings I'll write are listed below. Please confirm or edit before I implement:
+   - Network/fetch failure: *"Something went wrong while uploading. Please check your connection and try again."*
+   - ID process failure (Express 500): *"Failed to process ID document. Please try again."*
+   - Status labels: verified → **"Verified"**, pending → **"Under Review"**, manual_review → **"Under Manual Review"**, rejected/failed → **"Not Verified"**
+
+2. **Bug B — global error handler (`server.js`):** The dev-mode handler leaks `err.message` and `err.stack`. Should I fix that in this PR too (simple one-liner — remove the `isDev` branch and always return `"Internal Server Error"`)? Marking it out-of-scope for now unless you say otherwise.
+
+3. **Bug A — `public.users` schema:** The investigation confirms `dob` is stored in `public.users.dob`. Is the column definitely named `dob` (not `date_of_birth` or `birth_date`) in the actual Supabase schema? The registration code uses `dob` — assuming that's correct unless you say otherwise.


### PR DESCRIPTION
## Summary

Fixes 10 bugs across the identity verification pipeline spanning backend data handling, AI service OCR/NSOPW routing, and frontend display logic.

### Backend (`verificationController.js`)
- **P2-1** — `uploadId` changed from UPSERT to INSERT so every attempt is preserved as its own history row
- **P2-2** — `face_match_score` was always `0.0`; wrong field name `similarity_score` → `similarity`
- **P2-3** — `uploadSelfie` 500 responses leaked the full stack trace; replaced with a safe static message
- **P2-7** — City extracted from OCR address string and threaded through to the NSOPW call (required for Chicago routing)
- **DOB mismatch** — After OCR, if extracted DOB differs from profile `dob`, profile is auto-updated and `dobMismatch` flag returned to frontend

### AI Services (`nsopw_service.py`, `nsopw_routes.py`, `ocr_service.py`)
- **P2-7** — Added `city` field to `NsopwCheckBody`; four jurisdiction REST helpers (Iowa SOR, Missouri MSHP ArcGIS, DC GIS FeatureServer, Chicago Socrata) short-circuit before the Playwright NSOPW scraper; failures fall back gracefully
- **OCR DL** — Improved driver licence number extraction patterns; fixed 8-digit date filter; added all-numeric fallback patterns

### Frontend (`VerificationDetailsModal.tsx`, `verify/index.tsx`)
- **P2-4/5/6** — Fixed all field mappings: `ocr_result.extractedName/DOB/documentNumber/confidence`, `face_match_result.similarity/matched`, `nsopw_result.nsopwStatus/matchFound`
- **Status icons** — Section icons derived from actual result fields (`matched` boolean for Face Match, extracted-field presence for OCR) — not the unreliable AI `status` string
- **Badge colours** — Added missing colours for `manual_review` and `rejected` overall-status states
- **Labels** — `pending` to "Manual Review", `unverified` to "Not Started"
- **Prefill** — Supabase session fallback so the prefill fetch runs even when `userId` prop is not yet hydrated
- **DOB mismatch** — Amber info banner shown in the OCR results card when the profile DOB was updated to match the document

## Tests

| Test ID | Type | Covers |
|---------|------|--------|
| VER-PREFILL-01/02 (fixed) | Jest unit | Single-chain mock with dob field |
| VER-INSERT-01 (new) | Jest unit | uploadId calls insert not upsert |
| VER-SELFIE-01 (new) | Jest unit | face_match_score stored from similarity |
| VER-SELFIE-02 (new) | Jest unit | uploadSelfie 500 does not leak stack trace |
| REG-01 through REG-06 (new) | pytest async | Jurisdiction routing and fallback in check_nsopw |

## CI gate results (local pre-push)
- Backend Jest: 170/170 pass, ESLint clean
- Frontend: Vite build ok, ESLint clean, TypeScript zero errors
- AI Services: 60/60 pytest pass, flake8 clean

Generated with [Claude Code](https://claude.com/claude-code)