### PR TITLE
hotfix: allow free-form complaint subjects

### DIFF
--- a/backend/src/controllers/complaintController.js
+++ b/backend/src/controllers/complaintController.js
@@ -1,13 +1,10 @@
 import supabase from '../config/supabase.js';
 import { getInternalUser, profileNotFoundResponse } from '../utils/internalUser.js';
 
-// Subjects accepted by the complaints_subject_check DB constraint. Keep this
-// in sync with the Postgres CHECK constraint on public.complaints.subject.
-export const ALLOWED_COMPLAINT_SUBJECTS = [
-  'Provider did not show up',
-  'Safety concern',
-  'Other',
-];
+// Subject length bounds — generous enough for free-form text, tight enough
+// to block accidental empty / pathological inputs.
+const SUBJECT_MIN_LENGTH = 5;
+const SUBJECT_MAX_LENGTH = 200;
 
 // POST /api/complaints
 export const createComplaint = async (req, res) => {
@@ -18,12 +15,12 @@ export const createComplaint = async (req, res) => {
       return res.status(400).json({ success: false, error: 'subject and description are required' });
     }
 
-    if (!ALLOWED_COMPLAINT_SUBJECTS.includes(subject)) {
+    const trimmedSubject = String(subject).trim();
+    if (trimmedSubject.length < SUBJECT_MIN_LENGTH || trimmedSubject.length > SUBJECT_MAX_LENGTH) {
       return res.status(400).json({
         success: false,
-        error: 'Invalid subject',
-        message: `Subject must be one of: ${ALLOWED_COMPLAINT_SUBJECTS.join(', ')}.`,
-        allowedSubjects: ALLOWED_COMPLAINT_SUBJECTS,
+        error: 'Invalid subject length',
+        message: `Subject must be between ${SUBJECT_MIN_LENGTH} and ${SUBJECT_MAX_LENGTH} characters.`,
       });
     }
 
@@ -35,7 +32,7 @@ export const createComplaint = async (req, res) => {
       .insert({
         user_id:     internalUser.id,
         booking_id:  booking_id || null,
-        subject,
+        subject:     trimmedSubject,
         description,
         priority:    priority || 'MEDIUM',
         status:      'OPEN'

--- a/backend/src/scripts/2026_05_07_drop_complaints_subject_check.sql
+++ b/backend/src/scripts/2026_05_07_drop_complaints_subject_check.sql
@@ -1,0 +1,13 @@
+-- =============================================================================
+-- Migration: drop complaints.subject CHECK constraint
+-- Date:      2026-05-07
+-- Issue:     The complaints_subject_check constraint forced a small predefined
+--            list of subjects, but a complaint title is inherently free-form —
+--            users should be able to describe their issue in their own words.
+--
+-- Fix:       Drop the CHECK entirely. Length bounds (5–200 chars) are enforced
+--            by the controller (see complaintController.js).
+-- =============================================================================
+
+ALTER TABLE public.complaints
+  DROP CONSTRAINT IF EXISTS complaints_subject_check;

--- a/frontend/src/components/SupportModal.tsx
+++ b/frontend/src/components/SupportModal.tsx
@@ -37,7 +37,7 @@ export const SupportModal: React.FC<SupportModalProps> = ({
   userRole,
 }) => {
   const subjectOptions = userRole === "provider" ? PROVIDER_SUBJECTS : CUSTOMER_SUBJECTS;
-  const [subject, setSubject] = useState(subjectOptions[0]);
+  const [subject, setSubject] = useState("");
   const [description, setDescription] = useState("");
   const [priority, setPriority] = useState<Priority>("MEDIUM");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -47,7 +47,7 @@ export const SupportModal: React.FC<SupportModalProps> = ({
   if (!isOpen) return null;
 
   const resetForm = () => {
-    setSubject(subjectOptions[0]);
+    setSubject("");
     setDescription("");
     setPriority("MEDIUM");
     setError(null);
@@ -176,18 +176,25 @@ export const SupportModal: React.FC<SupportModalProps> = ({
                 <label className="block text-sm font-bold text-slate-700 mb-2">
                   What is your issue about?
                 </label>
-                <select
+                <input
+                  type="text"
                   required
+                  minLength={5}
+                  maxLength={200}
+                  list="support-subject-suggestions"
                   value={subject}
                   onChange={(e) => setSubject(e.target.value)}
+                  placeholder="Briefly describe your issue"
                   className="w-full px-4 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-700 bg-white focus:outline-none focus:ring-2 focus:ring-teal-400 focus:border-teal-400 transition"
-                >
+                />
+                <datalist id="support-subject-suggestions">
                   {subjectOptions.map((opt) => (
-                    <option key={opt} value={opt}>
-                      {opt}
-                    </option>
+                    <option key={opt} value={opt} />
                   ))}
-                </select>
+                </datalist>
+                <p className="mt-1 text-xs text-slate-400">
+                  Suggestions appear as you type. You can also write your own.
+                </p>
               </div>
 
               {/* Priority */}


### PR DESCRIPTION
## Summary
- Complaint subjects were locked to a 3-item whitelist (`Provider did not show up`, `Safety concern`, `Other`) by a Postgres CHECK constraint + server guard, so users couldn't describe issues in their own words.
- Drops the `complaints_subject_check` constraint, replaces the whitelist with a 5–200 char length bound in `complaintController.js`, and switches the `SupportModal` `<select>` to a free-form `<input>` with the old options surfaced as `<datalist>` suggestions.

## Files
- `backend/src/scripts/2026_05_07_drop_complaints_subject_check.sql` — migration
- `backend/src/controllers/complaintController.js` — length validation, trims input
- `frontend/src/components/SupportModal.tsx` — input + datalist

## Test plan
- [ ] Run the SQL migration against Supabase
- [ ] Submit a complaint with a custom subject (e.g. "Tech arrived 2 hours late and damaged my door") — should succeed
- [ ] Submit with subject < 5 chars — should 400
- [ ] Submit with subject > 200 chars — should 400
- [ ] Suggestion list still appears as you type