### PR TITLE
Implement provider booking approval flow and availability management

### DIFF
--- a/backend/src/controllers/availabilityController.js
+++ b/backend/src/controllers/availabilityController.js
@@ -20,6 +20,7 @@ export const getProviderAvailability = async (req, res) => {
       .select('id, date, start_time, end_time, is_booked')
       .eq('provider_id', providerId)
       .eq('date', date)
+      .eq('is_booked', false)
       .order('start_time', { ascending: true });
 
     if (error) {

--- a/backend/src/controllers/bookingController.js
+++ b/backend/src/controllers/bookingController.js
@@ -33,10 +33,10 @@ export const createBooking = async (req, res) => {
       address_zip,
     } = req.body;
 
-    if (!provider_id || !service_id || !scheduled_at) {
+    if (!provider_id || !service_id || !availability_id || !scheduled_at) {
       return res.status(400).json({
         success: false,
-        error: 'provider_id, service_id and scheduled_at are required',
+        error: 'provider_id, service_id, availability_id and scheduled_at are required',
       });
     }
 
@@ -52,25 +52,6 @@ export const createBooking = async (req, res) => {
       return res.status(400).json({
         success: false,
         error: 'Booking must be scheduled at least 30 minutes from now',
-      });
-    }
-
-    const { data: conflicting, error: conflictError } = await supabase
-      .from('bookings')
-      .select('id')
-      .eq('provider_id', provider_id)
-      .eq('scheduled_at', scheduled_at)
-      .in('status', ['pending', 'confirmed'])
-      .limit(1);
-
-    if (conflictError) {
-      return res.status(400).json({ success: false, error: conflictError.message });
-    }
-    if (Array.isArray(conflicting) && conflicting.length > 0) {
-      return res.status(409).json({
-        success: false,
-        error: 'This time slot is no longer available. Please choose another time.',
-        code: 'SLOT_UNAVAILABLE',
       });
     }
 
@@ -159,13 +140,69 @@ export const createBooking = async (req, res) => {
       }
     }
 
+    const scheduledDateKey = scheduled_at.slice(0, 10);
+
+    const { data: slot, error: slotLookupError } = await supabase
+      .from('availability_slots')
+      .select('id, provider_id, date, start_time, end_time, is_booked')
+      .eq('id', availability_id)
+      .eq('provider_id', provider_id)
+      .maybeSingle();
+
+    if (slotLookupError) {
+      return res.status(400).json({ success: false, error: slotLookupError.message });
+    }
+    if (!slot || slot.date !== scheduledDateKey || slot.is_booked) {
+      return res.status(409).json({
+        success: false,
+        error: 'This time slot is no longer available. Please choose another time.',
+        code: 'SLOT_UNAVAILABLE',
+      });
+    }
+
+    const { data: conflicting, error: conflictError } = await supabase
+      .from('bookings')
+      .select('id')
+      .eq('provider_id', provider_id)
+      .eq('scheduled_at', scheduled_at)
+      .in('status', ['pending', 'confirmed'])
+      .limit(1);
+
+    if (conflictError) {
+      return res.status(400).json({ success: false, error: conflictError.message });
+    }
+    if (Array.isArray(conflicting) && conflicting.length > 0) {
+      return res.status(409).json({
+        success: false,
+        error: 'This time slot is no longer available. Please choose another time.',
+        code: 'SLOT_UNAVAILABLE',
+      });
+    }
+
+    const { data: reservedSlot, error: availabilityError } = await supabase
+      .from('availability_slots')
+      .update({ is_booked: true })
+      .eq('id', availability_id)
+      .eq('provider_id', provider_id)
+      .eq('is_booked', false)
+      .select('id')
+      .single();
+
+    if (availabilityError || !reservedSlot) {
+      return res.status(409).json({
+        success: false,
+        error: 'This time slot is no longer available. Please choose another time.',
+        code: 'SLOT_UNAVAILABLE',
+      });
+    }
+
     const { data: booking, error } = await supabase
       .from('bookings')
       .insert({
         customer_id:     internalUser.id,
         provider_id,
         service_id,
-        availability_id: null,
+        availability_id,
         scheduled_at,
         notes:           notes || null,
         total_price:     priceToCharge,
@@ -180,18 +217,11 @@ export const createBooking = async (req, res) => {
       .single();
 
     if (error) {
-      return res.status(400).json({ success: false, error: error.message });
-    }
-
-    // ── B3 FIX: correct table name (was 'availability', should be 'availability_slots')
-    if (availability_id) {
-      const { error: availabilityError } = await supabase
+      await supabase
         .from('availability_slots')
-        .update({ is_booked: true })
+        .update({ is_booked: false })
         .eq('id', availability_id);
-      if (availabilityError) {
-        return res.status(400).json({ success: false, error: availabilityError.message });
-      }
+      return res.status(400).json({ success: false, error: error.message });
     }
 
     res.status(201).json({ success: true, data: booking });
@@ -349,7 +379,7 @@ export const acceptBooking = async (req, res) => {
 
     const { data: existing } = await supabase
       .from('bookings')
-      .select('id, provider_id, status')
+      .select('id, provider_id, availability_id, status')
       .eq('id', req.params.id)
       .single();
 
@@ -437,14 +467,27 @@ export const rejectBooking = async (req, res) => {
         cancellation_reason: req.body.reason || 'Rejected by provider',
       })
       .eq('id', req.params.id)
+      .eq('provider_id', provider.id)
+      .in('status', ['pending', 'confirmed'])
       .select()
       .single();
 
     if (error || !booking) {
-      return res.status(400).json({
+      return res.status(409).json({
         success: false,
-        error: error?.message || 'Failed to update booking',
+        error: error?.message || 'Booking status was changed by another request. Please refresh.',
       });
+    }
+
+    if (existing.availability_id) {
+      const { error: releaseError } = await supabase
+        .from('availability_slots')
+        .update({ is_booked: false })
+        .eq('id', existing.availability_id);
+
+      if (releaseError) {
+        return res.status(400).json({ success: false, error: releaseError.message });
+      }
     }
 
     res.json({ success: true, data: booking });

--- a/backend/src/controllers/bookingController.js
+++ b/backend/src/controllers/bookingController.js
@@ -33,10 +33,10 @@ export const createBooking = async (req, res) => {
       address_zip,
     } = req.body;
 
-    if (!provider_id || !service_id || !availability_id || !scheduled_at) {
+    if (!provider_id || !service_id || !scheduled_at) {
       return res.status(400).json({
         success: false,
-        error: 'provider_id, service_id, availability_id and scheduled_at are required',
+        error: 'provider_id, service_id and scheduled_at are required',
       });
     }
 
@@ -138,6 +138,13 @@ export const createBooking = async (req, res) => {
       if (providerService.custom_price !== null) {
         priceToCharge = providerService.custom_price;
       }
+    }
+
+    if (!availability_id) {
+      return res.status(400).json({
+        success: false,
+        error: 'availability_id is required',
+      });
     }
 
     const scheduledDateKey = scheduled_at.slice(0, 10);

--- a/backend/src/controllers/customerDashboardController.js
+++ b/backend/src/controllers/customerDashboardController.js
@@ -1,17 +1,9 @@
 import supabase from '../config/supabase.js';
 import { getInternalUser, profileNotFoundResponse } from '../utils/internalUser.js';
 
-// DB stores 'pending' and 'confirmed'; the API surface exposes both as 'upcoming'.
-// 'cancelled' in DB maps directly to 'cancelled' in the response.
 const UPCOMING_DB_STATUSES = ['pending', 'confirmed'];
 
 const VALID_API_STATUSES = new Set(['upcoming', 'completed', 'cancelled']);
-
-/** Maps a raw DB status string to the API-facing status label. */
-function toApiStatus(dbStatus) {
-  if (dbStatus === 'pending' || dbStatus === 'confirmed') return 'upcoming';
-  return dbStatus; // 'completed' | 'cancelled' pass through unchanged
-}
 
 /**
  * GET /api/dashboard/customer
@@ -89,7 +81,7 @@ export const getCustomerDashboard = async (req, res) => {
       serviceName:  b.service?.name          ?? null,
       providerName: b.provider?.business_name ?? null,
       date:         b.scheduled_at,
-      status:       toApiStatus(b.status),
+      status:       b.status,
     }));
 
     // Post-filter by provider name (case-insensitive substring)

--- a/backend/src/tests/Sprinta.test.js
+++ b/backend/src/tests/Sprinta.test.js
@@ -141,6 +141,7 @@ const SERVICE_OK         = { id: 'svc-1', base_price: 100, provider_id: 'prov-1'
 const SERVICE_OTHER_PROV = { id: 'svc-2', base_price: 80,  provider_id: 'prov-other', is_active: true };
 const BOOKING_PENDING    = { id: 'bk-1', customer_id: 'user-cust-1', provider_id: 'prov-1', status: 'pending' };
 const BOOKING_CONFIRMED  = { id: 'bk-1', customer_id: 'user-cust-1', provider_id: 'prov-1', status: 'confirmed' };
+const SLOT_AVAILABLE     = { id: 'slot-1', provider_id: 'prov-1', date: '', start_time: '10:00', end_time: '11:00', is_booked: false };
 
 // ── Global cleanup ────────────────────────────────────────────────────────
 beforeEach(() => {
@@ -362,7 +363,6 @@ describe('A-05 · createBooking — self-booking prevention', () => {
     // user_id to match the internal customer id.
     mockAs('customer');
     queue(
-      { data: [], error: null },                 // no slot conflict
       // provider.user_id === internalUser.id  → self-booking detected
       { data: { id: 'prov-1', is_fully_verified: true, user_id: 'user-cust-1' }, error: null },
       { data: INTERNAL_CUSTOMER, error: null },   // internalUser.id === 'user-cust-1'
@@ -377,15 +377,17 @@ describe('A-05 · createBooking — self-booking prevention', () => {
   it('allows a customer to book a verified provider', async () => {
     mockAs('customer');
     queue(
-      { data: [], error: null },
       { data: { id: 'prov-1', is_fully_verified: true, user_id: 'user-prov-1' }, error: null },
       { data: INTERNAL_CUSTOMER, error: null },   // different user_id → OK
       { data: SERVICE_OK, error: null },
-      { data: { id: 'bk-new', status: 'pending' }, error: null },
+      { data: { ...SLOT_AVAILABLE, date: TOMORROW.slice(0, 10) }, error: null },
+      { data: [], error: null },
+      { data: { id: 'slot-1' }, error: null },
+      { data: { id: 'bk-new', status: 'pending', availability_id: 'slot-1' }, error: null },
     );
     const res = await request(app)
       .post('/api/bookings').set('Authorization', 'Bearer tok')
-      .send({ provider_id: 'prov-1', service_id: 'svc-1', scheduled_at: TOMORROW });
+      .send({ provider_id: 'prov-1', service_id: 'svc-1', availability_id: 'slot-1', scheduled_at: TOMORROW });
     expect(res.statusCode).toBe(201);
   });
 });
@@ -544,14 +546,13 @@ describe('A-11 · createBooking — service/provider ownership', () => {
   it('returns 400 when service belongs to a different provider', async () => {
     mockAs('customer');
     queue(
-      { data: [], error: null },
       { data: { id: 'prov-1', is_fully_verified: true, user_id: 'user-prov-1' }, error: null },
       { data: INTERNAL_CUSTOMER, error: null },
       { data: SERVICE_OTHER_PROV, error: null },   // provider_id mismatch
     );
     const res = await request(app)
       .post('/api/bookings').set('Authorization', 'Bearer tok')
-      .send({ provider_id: 'prov-1', service_id: 'svc-2', scheduled_at: TOMORROW });
+      .send({ provider_id: 'prov-1', service_id: 'svc-2', availability_id: 'slot-1', scheduled_at: TOMORROW });
     expect(res.statusCode).toBe(400);
     expect(res.body.error).toMatch(/does not belong/i);
   });
@@ -559,14 +560,13 @@ describe('A-11 · createBooking — service/provider ownership', () => {
   it('returns 400 when service is inactive', async () => {
     mockAs('customer');
     queue(
-      { data: [], error: null },
       { data: { id: 'prov-1', is_fully_verified: true, user_id: 'user-prov-1' }, error: null },
       { data: INTERNAL_CUSTOMER, error: null },
       { data: { ...SERVICE_OK, is_active: false }, error: null },
     );
     const res = await request(app)
       .post('/api/bookings').set('Authorization', 'Bearer tok')
-      .send({ provider_id: 'prov-1', service_id: 'svc-1', scheduled_at: TOMORROW });
+      .send({ provider_id: 'prov-1', service_id: 'svc-1', availability_id: 'slot-1', scheduled_at: TOMORROW });
     expect(res.statusCode).toBe(400);
     expect(res.body.error).toMatch(/no longer available/i);
   });

--- a/backend/src/tests/app.test.js
+++ b/backend/src/tests/app.test.js
@@ -800,7 +800,20 @@ describe('Bookings – POST /api/bookings', () => {
   it('returns 409 when the requested slot is already booked', async () => {
     mockCustomerAuth();
     supabaseAwaitQueue.push(
-      { data: [{ id: 'existing-booking' }], error: null },
+      { data: { id: 'prov-1', is_fully_verified: true, user_id: 'prov-user-uuid' }, error: null },
+      { data: { id: 'internal-customer-1', role: 'customer' }, error: null },
+      { data: { id: 'svc-1', base_price: 125, provider_id: 'prov-1', is_active: true }, error: null },
+      {
+        data: {
+          id: 'slot-1',
+          provider_id: 'prov-1',
+          date: '2026-08-10',
+          start_time: '10:00',
+          end_time: '11:00',
+          is_booked: true,
+        },
+        error: null,
+      },
     );
 
     const res = await request(app)
@@ -809,6 +822,7 @@ describe('Bookings – POST /api/bookings', () => {
       .send({
         provider_id: 'prov-1',
         service_id: 'svc-1',
+        availability_id: 'slot-1',
         scheduled_at: '2026-08-10T10:00:00.000Z',
       });
 
@@ -819,18 +833,32 @@ describe('Bookings – POST /api/bookings', () => {
 
   it('creates booking successfully when slot is free', async () => {
     mockCustomerAuth();
+    const futureIso = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString();
 
     supabaseAwaitQueue.push(
-      { data: [], error: null },
       { data: { id: 'prov-1', is_fully_verified: true, user_id: 'prov-user-uuid' }, error: null },
       { data: { id: 'internal-customer-1', role: 'customer' }, error: null },
       { data: { id: 'svc-1', base_price: 125, provider_id: 'prov-1', is_active: true }, error: null },
       {
         data: {
+          id: 'slot-1',
+          provider_id: 'prov-1',
+          date: futureIso.slice(0, 10),
+          start_time: '10:00',
+          end_time: '11:00',
+          is_booked: false,
+        },
+        error: null,
+      },
+      { data: [], error: null },
+      { data: { id: 'slot-1' }, error: null },
+      {
+        data: {
           id: 'booking-1',
           provider_id: 'prov-1',
           service_id: 'svc-1',
-          scheduled_at: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString(),
+          availability_id: 'slot-1',
+          scheduled_at: futureIso,
           total_price: 125,
           status: 'pending',
         },
@@ -844,16 +872,59 @@ describe('Bookings – POST /api/bookings', () => {
       .send({
         provider_id:  'prov-1',
         service_id:   'svc-1',
-        scheduled_at: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString(),
+        availability_id: 'slot-1',
+        scheduled_at: futureIso,
       });
 
     expect(res.statusCode).toBe(201);
     expect(res.body.success).toBe(true);
     expect(res.body.data).toMatchObject({
       id: 'booking-1',
+      availability_id: 'slot-1',
       status: 'pending',
       total_price: 125,
     });
+  });
+
+  it('rejecting a booking reopens its linked availability slot', async () => {
+    mockProviderAuth();
+    supabaseAwaitQueue.push(
+      { data: { id: 'internal-provider-1', role: 'provider' }, error: null },
+      { data: { id: 'prov-1' }, error: null },
+      {
+        data: {
+          id: 'booking-1',
+          provider_id: 'prov-1',
+          availability_id: 'slot-1',
+          status: 'pending',
+        },
+        error: null,
+      },
+      {
+        data: {
+          id: 'booking-1',
+          provider_id: 'prov-1',
+          availability_id: 'slot-1',
+          status: 'cancelled',
+        },
+        error: null,
+      },
+      { data: { id: 'slot-1' }, error: null },
+    );
+
+    const res = await request(app)
+      .put('/api/bookings/booking-1/reject')
+      .set('Authorization', 'Bearer fake-jwt')
+      .send({ reason: 'Declined by provider' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      id: 'booking-1',
+      status: 'cancelled',
+      availability_id: 'slot-1',
+    });
+    expect(supabaseAwaitQueue).toHaveLength(0);
   });
 });
 

--- a/frontend/src/components/BookingModal.tsx
+++ b/frontend/src/components/BookingModal.tsx
@@ -120,8 +120,6 @@ export const BookingModal: React.FC<BookingModalProps> = ({
   // Submission
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Tracks whether displayed slots are real provider slots or generated fallbacks
-  const [usedFallback, setUsedFallback] = useState(false);
   const errorRef = useRef<HTMLDivElement | null>(null);
 
   // Scroll the error into view whenever it appears so users actually see
@@ -148,7 +146,7 @@ export const BookingModal: React.FC<BookingModalProps> = ({
       setSlotsLoading(true);
       setSlots([]);
       setSelectedSlot(null);
-      setUsedFallback(false);
+      setError(null);
       const dateStr = toLocalDate(selectedDate!);
       try {
         const res = await fetch(
@@ -159,26 +157,23 @@ export const BookingModal: React.FC<BookingModalProps> = ({
           }
         );
         const json = await res.json();
-        if (json.success && Array.isArray(json.data)) {
-          const available: Slot[] = (json.data as SlotRaw[])
-            .filter((s) => !s.is_booked)
-            .map((s) => ({
-              id: s.id,
-              startTime: s.start_time,
-              endTime: s.end_time,
-              label: `${fmt12h(s.start_time)} – ${fmt12h(s.end_time)}`,
-            }));
-          setUsedFallback(false);
-          setSlots(available);
+        if (!res.ok || !json.success || !Array.isArray(json.data)) {
+          setError(json.error || "Could not load availability. Please try another date or retry.");
+          setSlots([]);
+          return;
         } else {
-          // No availability endpoint yet — fall back to generated slots
-          setUsedFallback(true);
-          setSlots(generateFallbackSlots());
+          const available: Slot[] = (json.data as SlotRaw[]).map((s) => ({
+            id: s.id,
+            startTime: s.start_time,
+            endTime: s.end_time,
+            label: `${fmt12h(s.start_time)} – ${fmt12h(s.end_time)}`,
+          }));
+          setSlots(available);
         }
       } catch {
         if (!controller.signal.aborted) {
-          setUsedFallback(true);
-          setSlots(generateFallbackSlots());
+          setSlots([]);
+          setError("Could not load availability. Please check your connection and try again.");
         }
       } finally {
         if (!controller.signal.aborted) setSlotsLoading(false);
@@ -188,22 +183,6 @@ export const BookingModal: React.FC<BookingModalProps> = ({
     fetchSlots();
     return () => controller.abort();
   }, [selectedDate, providerId, token]);
-
-  /** Fallback: generate 9am–5pm hourly slots when no availability API data */
-  function generateFallbackSlots(): Slot[] {
-    const out: Slot[] = [];
-    for (let h = 9; h < 17; h++) {
-      const start = `${String(h).padStart(2, "0")}:00`;
-      const end = `${String(h + 1).padStart(2, "0")}:00`;
-      out.push({
-        id: `fallback-${h}`,
-        startTime: start,
-        endTime: end,
-        label: `${fmt12h(start)} – ${fmt12h(end)}`,
-      });
-    }
-    return out;
-  }
 
   // ── Submit booking ─────────────────────────────────────────────────────────
   async function handleBook() {
@@ -224,12 +203,8 @@ export const BookingModal: React.FC<BookingModalProps> = ({
       address_city: addressCity.trim() || undefined,
       address_state: addressState.trim() || undefined,
       address_zip: addressZip.trim() || undefined,
+      availability_id: selectedSlot.id,
     };
-
-    // Only include availability_id if it's a real slot (not fallback)
-    if (!selectedSlot.id.startsWith("fallback-")) {
-      body.availability_id = selectedSlot.id;
-    }
 
     try {
       const res = await fetch(`${API_BASE}/api/bookings`, {
@@ -384,14 +359,6 @@ export const BookingModal: React.FC<BookingModalProps> = ({
                 </p>
               ) : (
                 <>
-                  {usedFallback && (
-                    <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-xl px-3 py-2.5 mb-2 text-xs text-amber-800">
-                      <span className="mt-0.5">⚠️</span>
-                      <span>
-                        <span className="font-bold">Suggested times only</span> — this provider hasn't set specific availability. These are general windows. The provider will confirm your chosen time after booking.
-                      </span>
-                    </div>
-                  )}
                   <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                   {slots.map((slot) => (
                     <button

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -69,12 +69,22 @@ export const Navbar: React.FC<NavbarProps> = ({
                   </span>
                 </>
               ) : (
-                <span
-                  onClick={() => onNavigate(getHomePath())}
-                  className={navItemClass(getHomePath())}
-                >
-                  Home
-                </span>
+                <>
+                  <span
+                    onClick={() => onNavigate(getHomePath())}
+                    className={navItemClass(getHomePath())}
+                  >
+                    Home
+                  </span>
+                  {user?.role === UserRole.PROVIDER && (
+                    <span
+                      onClick={() => onNavigate("/my-bookings")}
+                      className={navItemClass("/my-bookings")}
+                    >
+                      Bookings
+                    </span>
+                  )}
+                </>
               )}
               <span
                 onClick={() => onNavigate("/faq")}
@@ -166,12 +176,22 @@ export const Navbar: React.FC<NavbarProps> = ({
                 </div>
               </>
             ) : (
-              <div
-                className="block px-4 py-3 rounded-2xl text-base font-semibold text-slate-700 hover:bg-slate-50"
-                onClick={() => { onNavigate(getHomePath()); setIsOpen(false); }}
-              >
-                Home
-              </div>
+              <>
+                <div
+                  className="block px-4 py-3 rounded-2xl text-base font-semibold text-slate-700 hover:bg-slate-50"
+                  onClick={() => { onNavigate(getHomePath()); setIsOpen(false); }}
+                >
+                  Home
+                </div>
+                {user?.role === UserRole.PROVIDER && (
+                  <div
+                    className="block px-4 py-3 rounded-2xl text-base font-semibold text-slate-700 hover:bg-slate-50"
+                    onClick={() => { onNavigate("/my-bookings"); setIsOpen(false); }}
+                  >
+                    Bookings
+                  </div>
+                )}
+              </>
             )}
             {user && (
               <div

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,13 +1,25 @@
 import React from "react";
 import { Clock, CheckCircle2, XCircle } from "lucide-react";
 
-export type BookingStatus = "upcoming" | "completed" | "cancelled";
+export type BookingStatus = "pending" | "confirmed" | "upcoming" | "completed" | "cancelled";
 
 // Mirrors the BADGE_CONFIG pattern in VerificationBadge.tsx
 const BADGE_CONFIG: Record<
   BookingStatus,
   { label: string; bg: string; text: string; icon: React.ReactNode }
 > = {
+  pending: {
+    label: "Pending provider approval",
+    bg: "bg-amber-50 border-amber-200",
+    text: "text-amber-700",
+    icon: <Clock size={14} className="text-amber-600" />,
+  },
+  confirmed: {
+    label: "Confirmed",
+    bg: "bg-teal-50 border-teal-200",
+    text: "text-teal-700",
+    icon: <CheckCircle2 size={14} className="text-teal-600" />,
+  },
   upcoming: {
     label: "Upcoming",
     bg: "bg-amber-50 border-amber-200",

--- a/frontend/src/pages/CustomerDashboard.tsx
+++ b/frontend/src/pages/CustomerDashboard.tsx
@@ -33,10 +33,6 @@ const WARN_LABELS: Record<string, string> = {
 
 const POLICY_ITEMS = [
   {
-    title: "Free cancellation",
-    desc: "Cancel up to 24 hours before your appointment at no charge.",
-  },
-  {
     title: "Late cancellation",
     desc: "Cancellations within 24 hours may incur a fee set by the provider.",
   },

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { ServiceCategory } from "../../types";
 import type { User, Provider } from "../../types";
-import { Star, ArrowRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { ServiceCatalogModal } from "../components/ServiceCatalogModal";
 
 const SERVICE_ICONS: Record<string, string> = {
@@ -65,12 +65,6 @@ export const Home: React.FC<HomeProps> = ({ onNavigate, user }) => {
     <div className="flex flex-col min-h-[calc(100vh-100px)]">
       <section className="relative py-20 lg:py-32 overflow-visible">
         <div className="relative max-w-5xl mx-auto px-4 text-center z-10">
-          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/60 border border-white/60 shadow-sm backdrop-blur-md mb-8 animate-float">
-            <Star size={14} className="text-amber-500 fill-amber-500" />
-            <span className="text-xs font-bold text-slate-600 uppercase tracking-wider">
-              Trusted by 10k+ Homeowners
-            </span>
-          </div>
           <h1 className="text-5xl sm:text-7xl lg:text-8xl font-bold text-slate-900 tracking-tighter mb-8 leading-[0.95]">
             Home services, <br />
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-teal-600 to-emerald-500">

--- a/frontend/src/pages/ProviderBookings.tsx
+++ b/frontend/src/pages/ProviderBookings.tsx
@@ -125,7 +125,12 @@ export const ProviderBookings: React.FC<ProviderBookingsProps> = ({
           [bookingId]: json.error || `Failed to ${action} booking.`,
         }));
       } else {
-        const newStatus = action === "accept" ? "confirmed" : "cancelled";
+        const newStatus =
+          typeof json.data?.status === "string"
+            ? json.data.status
+            : action === "accept"
+              ? "confirmed"
+              : "cancelled";
         setBookings((prev) =>
           prev.map((b) => (b.id === bookingId ? { ...b, status: newStatus } : b)),
         );

--- a/frontend/src/pages/ProviderDashboard.tsx
+++ b/frontend/src/pages/ProviderDashboard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FC } from "react";
-import { Calendar, Loader2, AlertCircle, ChevronLeft, ChevronRight } from "lucide-react";
+import { Calendar, Loader2, AlertCircle, ChevronLeft, ChevronRight, CheckCircle, XCircle } from "lucide-react";
 import type { User, Provider } from "../../types";
 import { UserRole } from "../../types";
 
@@ -47,6 +47,8 @@ interface CalendarEvent {
   service_name: string | null;
   customer_name?: string | null;
 }
+
+type BookingAction = "accept" | "reject";
 
 interface ProviderDashboardData {
   stats: DashboardStats;
@@ -154,10 +156,16 @@ function BreakdownList({
   title,
   rows,
   emptyHint,
+  onAction,
+  actionLoading,
+  actionError,
 }: {
   title: string;
   rows: BreakdownRow[];
   emptyHint: string;
+  onAction: (bookingId: string, action: BookingAction) => void;
+  actionLoading: Record<string, BookingAction | null>;
+  actionError: Record<string, string | null>;
 }) {
   return (
     <div className="rounded-2xl bg-white border border-slate-100 shadow-sm overflow-hidden">
@@ -171,6 +179,9 @@ function BreakdownList({
         ) : (
           rows.map((row) => {
             const when = new Date(row.scheduled_at);
+            const isPending = row.status === "pending";
+            const rowLoading = actionLoading[row.id];
+            const rowError = actionError[row.id];
             return (
               <li key={row.id} className="px-5 py-3.5 hover:bg-slate-50/60 transition-colors">
                 <div className="flex justify-between gap-2">
@@ -193,6 +204,41 @@ function BreakdownList({
                     {formatUsd(row.total_price)}
                   </span>
                 </div>
+                {rowError && (
+                  <div className="mt-2 rounded-lg border border-red-100 bg-red-50 px-3 py-2 text-xs font-medium text-red-700">
+                    {rowError}
+                  </div>
+                )}
+                {isPending && (
+                  <div className="mt-3 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onAction(row.id, "reject")}
+                      disabled={!!rowLoading}
+                      className="flex-1 inline-flex items-center justify-center gap-1.5 py-2 rounded-xl border border-red-200 text-red-600 font-semibold text-xs hover:bg-red-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {rowLoading === "reject" ? (
+                        <Loader2 size={13} className="animate-spin" />
+                      ) : (
+                        <XCircle size={13} />
+                      )}
+                      Reject
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onAction(row.id, "accept")}
+                      disabled={!!rowLoading}
+                      className="flex-1 inline-flex items-center justify-center gap-1.5 py-2 rounded-xl bg-teal-600 text-white font-bold text-xs hover:bg-teal-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {rowLoading === "accept" ? (
+                        <Loader2 size={13} className="animate-spin" />
+                      ) : (
+                        <CheckCircle size={13} />
+                      )}
+                      Accept
+                    </button>
+                  </div>
+                )}
               </li>
             );
           })
@@ -220,6 +266,8 @@ export const ProviderDashboard: FC<ProviderDashboardProps> = ({
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
   const [calendarStatuses, setCalendarStatuses] = useState<string[]>(["confirmed"]);
   const [lastRefreshedAt, setLastRefreshedAt] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<Record<string, BookingAction | null>>({});
+  const [actionError, setActionError] = useState<Record<string, string | null>>({});
   const hasLoadedDashboard = useRef(false);
   const allCalendarStatuses = ["pending", "confirmed", "completed", "cancelled"] as const;
 
@@ -305,6 +353,43 @@ export const ProviderDashboard: FC<ProviderDashboardProps> = ({
     }, 60000);
     return () => window.clearInterval(timer);
   }, [isProvider, token, load]);
+
+  const handleBookingAction = useCallback(async (bookingId: string, action: BookingAction) => {
+    setActionLoading((prev) => ({ ...prev, [bookingId]: action }));
+    setActionError((prev) => ({ ...prev, [bookingId]: null }));
+
+    try {
+      const res = await fetch(`${API_BASE}/api/bookings/${bookingId}/${action}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body:
+          action === "reject"
+            ? JSON.stringify({ reason: "Declined by provider" })
+            : undefined,
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setActionError((prev) => ({
+          ...prev,
+          [bookingId]: json.error || `Failed to ${action} booking.`,
+        }));
+        return;
+      }
+
+      setSelectedEvent((prev) => (prev?.id === bookingId ? null : prev));
+      await load({ calendarOnly: false, silent: true });
+    } catch {
+      setActionError((prev) => ({
+        ...prev,
+        [bookingId]: "Network error. Please try again.",
+      }));
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [bookingId]: null }));
+    }
+  }, [load, token]);
 
   const calendarItemsByDate = useMemo(() => {
     const map = new Map<string, CalendarEvent[]>();
@@ -554,6 +639,9 @@ export const ProviderDashboard: FC<ProviderDashboardProps> = ({
                 title="Bookings"
                 rows={bookingRows}
                 emptyHint="No bookings yet."
+                onAction={handleBookingAction}
+                actionLoading={actionLoading}
+                actionError={actionError}
               />
             </div>
 


### PR DESCRIPTION
This pull request introduces significant improvements to the booking flow, focusing on enforcing real-time slot availability, preventing double-booking, and removing fallback slot logic from the frontend. It also updates the backend and tests to require and validate `availability_id` for bookings, ensuring that only unbooked slots can be reserved. Additionally, the customer dashboard and booking rejection logic have been refined for accuracy and consistency.

**Backend booking validation and slot management:**

* The booking creation endpoint (`createBooking`) now requires an `availability_id`, verifies that the slot is available and not already booked, and marks the slot as booked upon successful reservation. It also releases the slot if booking creation fails, and prevents double-booking with stricter checks. [[1]](diffhunk://#diff-51083c54781729169205b629bd58822f8d71534d6486dc8a0a9d9ae229c7458bL58-L76) [[2]](diffhunk://#diff-51083c54781729169205b629bd58822f8d71534d6486dc8a0a9d9ae229c7458bR143-R212) [[3]](diffhunk://#diff-51083c54781729169205b629bd58822f8d71534d6486dc8a0a9d9ae229c7458bL183-R231)
* The booking rejection endpoint (`rejectBooking`) now releases the associated slot (sets `is_booked` to false) when a booking is rejected, and tightens status checks to avoid race conditions.
* The provider availability endpoint (`getProviderAvailability`) now only returns slots that are not booked (`is_booked: false`).

**Frontend slot selection and booking modal:**

* The booking modal (`BookingModal.tsx`) no longer generates fallback slots; it only displays real slots from the API, surfaces errors if slots cannot be loaded, and always includes `availability_id` in booking requests. [[1]](diffhunk://#diff-87d46dd874c3ba0191d5bd33cfd67a9e0157d38f49971d29e16d79f5b7277868L123-L124) [[2]](diffhunk://#diff-87d46dd874c3ba0191d5bd33cfd67a9e0157d38f49971d29e16d79f5b7277868L151-R149) [[3]](diffhunk://#diff-87d46dd874c3ba0191d5bd33cfd67a9e0157d38f49971d29e16d79f5b7277868L162-R176) [[4]](diffhunk://#diff-87d46dd874c3ba0191d5bd33cfd67a9e0157d38f49971d29e16d79f5b7277868L192-L207) [[5]](diffhunk://#diff-87d46dd874c3ba0191d5bd33cfd67a9e0157d38f49971d29e16d79f5b7277868R206-L233)

**Test updates for slot-based booking:**

* All booking-related tests now provide `availability_id` and mock slot lookups and updates, ensuring that tests reflect the new slot reservation logic. A new test verifies that rejecting a booking reopens its slot. [[1]](diffhunk://#diff-ba7fa046882256841a2bbd433765a353da2baa95d9ce99a53fdafe19e8874321R144) [[2]](diffhunk://#diff-ba7fa046882256841a2bbd433765a353da2baa95d9ce99a53fdafe19e8874321L380-R390) [[3]](diffhunk://#diff-ba7fa046882256841a2bbd433765a353da2baa95d9ce99a53fdafe19e8874321L547-R569) [[4]](diffhunk://#diff-2aa84b0db32824900fe6c28a8c85be97650953433e60deca277f3ce1a192e62cL803-R816) [[5]](diffhunk://#diff-2aa84b0db32824900fe6c28a8c85be97650953433e60deca277f3ce1a192e62cR825) [[6]](diffhunk://#diff-2aa84b0db32824900fe6c28a8c85be97650953433e60deca277f3ce1a192e62cR836-R861) [[7]](diffhunk://#diff-2aa84b0db32824900fe6c28a8c85be97650953433e60deca277f3ce1a192e62cL847-R928)

**Booking and dashboard status handling:**

* The customer dashboard now passes raw booking statuses directly without mapping them, simplifying status handling. [[1]](diffhunk://#diff-f6c6d5f4fcdcad85105c0c90973fbbc5255c53388272da0309614e59dd3125ebL4-L15) [[2]](diffhunk://#diff-f6c6d5f4fcdcad85105c0c90973fbbc5255c53388272da0309614e59dd3125ebL92-R84)

**Other minor improvements:**

* The `acceptBooking` endpoint now selects `availability_id` for consistency and potential future use.